### PR TITLE
Update for swift 5.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,9 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'swift:5.5'
           - 'swift:5.6'
           - 'swift:5.7'
+          - 'swift:5.8'
     
     container:
       image: ${{ matrix.image }}

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.6
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Sources/HummingbirdWSClient/WebSocketClient.swift
+++ b/Sources/HummingbirdWSClient/WebSocketClient.swift
@@ -116,7 +116,7 @@ public enum HBWebSocketClient {
     }
 
     /// WebSocket connection configuration
-    public struct Configuration {
+    public struct Configuration: Sendable {
         /// TLS setup
         let tlsConfiguration: TLSConfiguration
 
@@ -161,8 +161,6 @@ public enum HBWebSocketClient {
     }
 }
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
-
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension HBWebSocketClient {
     /// Connect to WebSocket
@@ -174,9 +172,3 @@ extension HBWebSocketClient {
         return try await self.connect(url: url, configuration: configuration, on: eventLoop).get()
     }
 }
-
-#endif // compiler(>=5.5.2) && canImport(_Concurrency)
-
-#if compiler(>=5.6)
-extension HBWebSocketClient.Configuration: Sendable {}
-#endif // compiler(>=5.6)

--- a/Sources/HummingbirdWSCore/WebSocket.swift
+++ b/Sources/HummingbirdWSCore/WebSocket.swift
@@ -17,7 +17,7 @@ import NIOWebSocket
 
 /// WebSocket object
 public final class HBWebSocket {
-    public enum SocketType {
+    public enum SocketType: Sendable {
         case client
         case server
     }
@@ -228,8 +228,6 @@ public final class HBWebSocket {
     private var isClosed: Bool = false
 }
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
-
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension HBWebSocket {
     /// Write data to WebSocket
@@ -267,11 +265,8 @@ extension HBWebSocket {
     }
 }
 
-#endif // compiler(>=5.5.2) && canImport(_Concurrency)
-
 #if compiler(>=5.6)
 // HBWebSocket can be set to Sendable because ping data which is mutable is
 // managed internally and is only ever changed on the event loop
 extension HBWebSocket: @unchecked Sendable {}
-extension HBWebSocket.SocketType: Sendable {}
 #endif // compiler(>=5.6)

--- a/Sources/HummingbirdWSCore/WebSocketData.swift
+++ b/Sources/HummingbirdWSCore/WebSocketData.swift
@@ -16,7 +16,7 @@ import NIOCore
 import NIOWebSocket
 
 /// Enumeration holding WebSocket data
-public enum WebSocketData: Equatable {
+public enum WebSocketData: Equatable, Sendable {
     case text(String)
     case binary(ByteBuffer)
 }
@@ -51,7 +51,3 @@ struct WebSocketFrameSequence {
         }
     }
 }
-
-#if compiler(>=5.6)
-extension WebSocketData: Sendable {}
-#endif // compiler(>=5.6)

--- a/Sources/HummingbirdWebSocket/Application+WebSocket.swift
+++ b/Sources/HummingbirdWebSocket/Application+WebSocket.swift
@@ -99,8 +99,6 @@ extension HBApplication {
     public var ws: HBWebSocketBuilder { .init(application: self) }
 }
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
-
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension HBWebSocketBuilder {
     /// Add WebSocket connection upgrade at given path
@@ -116,5 +114,3 @@ extension HBWebSocketBuilder {
         self.routerGroup.on(path, shouldUpgrade: shouldUpgrade, onUpgrade: onUpgrade)
     }
 }
-
-#endif // compiler(>=5.5.2) && canImport(_Concurrency)

--- a/Sources/HummingbirdWebSocket/WebSocketRouterGroup.swift
+++ b/Sources/HummingbirdWebSocket/WebSocketRouterGroup.swift
@@ -87,8 +87,6 @@ public struct HBWebSocketRouterGroup {
     }
 }
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
-
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension HBWebSocketRouterGroup {
     /// Add WebSocket connection upgrade at given path
@@ -120,5 +118,3 @@ extension HBWebSocketRouterGroup {
         )
     }
 }
-
-#endif // compiler(>=5.5.2) && canImport(_Concurrency)

--- a/Tests/HummingbirdWebSocketTests/WebSocketTests.swift
+++ b/Tests/HummingbirdWebSocketTests/WebSocketTests.swift
@@ -142,41 +142,6 @@ final class HummingbirdWebSocketTests: XCTestCase {
         try promise.wait()
     }
 
-    /* Commented out as ws://echo.websocket.org is not working anymore
-      func testClient() throws {
-         let eventLoop = Self.eventLoopGroup.next()
-         let promise = TimeoutPromise(eventLoop: Self.eventLoopGroup.next(), timeout: .seconds(10))
-
-         do {
-             let clientWS = try HBWebSocketClient.connect(url: "ws://echo.websocket.org", configuration: .init(), on: eventLoop).wait()
-             clientWS.onRead { data, _ in
-                 XCTAssertEqual(data, .text("Hello"))
-                 promise.succeed()
-             }
-             clientWS.write(.text("Hello"), promise: nil)
-         } catch {
-             promise.fail(error)
-         }
-         try promise.wait()
-     }
-
-     func testTLS() throws {
-         let eventLoop = Self.eventLoopGroup.next()
-         let promise = TimeoutPromise(eventLoop: Self.eventLoopGroup.next(), timeout: .seconds(10))
-
-         do {
-             let clientWS = try HBWebSocketClient.connect(url: "ws://echo.websocket.org", configuration: .init(), on: eventLoop).wait()
-             clientWS.onRead { data, _ in
-                 XCTAssertEqual(data, .text("Hello"))
-                 promise.succeed()
-             }
-             clientWS.write(.text("Hello"), promise: nil)
-         } catch {
-             promise.fail(error)
-         }
-         try promise.wait()
-     }*/
-
     func testNotWebSocket() throws {
         let app = HBApplication(configuration: .init(address: .hostname(port: 8080)))
         app.router.get("/test") { _ in
@@ -314,8 +279,6 @@ final class HummingbirdWebSocketTests: XCTestCase {
     }
 }
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
-
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension HummingbirdWebSocketTests {
     func testServerAsyncReadWrite() async throws {
@@ -343,5 +306,3 @@ extension HummingbirdWebSocketTests {
         try promise.wait()
     }
 }
-
-#endif // compiler(>=5.5.2) && canImport(_Concurrency)


### PR DESCRIPTION
Remove 5.5 preprocessor checks as we no longer support 5.5