### PR TITLE
HBWebSocketClient responds to server redirects

### DIFF
--- a/Sources/HummingbirdWSClient/WebSocketClient.swift
+++ b/Sources/HummingbirdWSClient/WebSocketClient.swift
@@ -159,7 +159,8 @@ public enum HBWebSocketClient {
     public struct Configuration: Sendable {
         /// TLS setup
         let tlsConfiguration: TLSConfiguration
-        /// Redirects
+        /// Redirects. RFC 6455 doesn't require clients to follow redirects and the whatwg spec says they
+        /// shouldn't be followed, but if you really want to, you can enable them via `followRedirects`.
         let followRedirects: Bool
         /// Maximum size for a single frame
         let maxFrameSize: Int

--- a/Tests/HummingbirdWebSocketTests/WebSocketTests.swift
+++ b/Tests/HummingbirdWebSocketTests/WebSocketTests.swift
@@ -433,7 +433,7 @@ extension HummingbirdWebSocketTests {
         let eventLoop = app.eventLoopGroup.next()
         let ws = try await HBWebSocketClient.connect(
             url: "ws://localhost:8080/test",
-            configuration: .init(),
+            configuration: .init(followRedirects: true),
             on: eventLoop
         )
         ws.onRead { data, _ in


### PR DESCRIPTION
Add support to HBWebSocketClient to respond to server redirects. Need to flag in config you want to follow redirects
```swift
let ws = try await HBWebSocketClient.connect(
    url: "ws://localhost:8080/test",
    configuration: .init(followRedirects: true),
    on: eventLoop
)
```