### PR TITLE
Improve Sendable conformance for HBWebSocket

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,7 @@ let package = Package(
         .library(name: "HummingbirdWSCore", targets: ["HummingbirdWSCore"]),
     ],
     dependencies: [
+        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.0"),
         .package(url: "https://github.com/hummingbird-project/hummingbird-core.git", from: "1.1.0"),
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "1.4.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.32.1"),
@@ -32,11 +33,13 @@ let package = Package(
         ]),
         .target(name: "HummingbirdWebSocket", dependencies: [
             .byName(name: "HummingbirdWSCore"),
+            .product(name: "Atomics", package: "swift-atomics"),
             .product(name: "Hummingbird", package: "hummingbird"),
         ]),
         .testTarget(name: "HummingbirdWebSocketTests", dependencies: [
             .byName(name: "HummingbirdWebSocket"),
             .byName(name: "HummingbirdWSClient"),
+            .product(name: "Atomics", package: "swift-atomics"),
         ]),
     ]
 )

--- a/Sources/HummingbirdWSCore/WebSocket.swift
+++ b/Sources/HummingbirdWSCore/WebSocket.swift
@@ -73,7 +73,7 @@ public final class HBWebSocket: Sendable {
                 return
             }
             self.waitingOnPong = false
-            ws.pongCallback.load(ordering: .relaxed).value?(ws)
+            ws.pongCallback.load(ordering: .relaxed).wrapped?(ws)
         }
 
         /// Send ping message
@@ -101,11 +101,12 @@ public final class HBWebSocket: Sendable {
     public typealias CloseCallback = @Sendable (HBWebSocket) -> Void
     public typealias PongCallback = @Sendable (HBWebSocket) -> Void
 
+    // wrapper class for type that conforms to AtomicReference
     final class AtomicContainer<Value: Sendable>: AtomicReference, Sendable {
-        let value: Value
+        let wrapped: Value
 
         init(_ value: Value) {
-            self.value = value
+            self.wrapped = value
         }
     }
 
@@ -235,7 +236,7 @@ public final class HBWebSocket: Sendable {
     }
 
     func read(_ data: WebSocketData) {
-        self.readCallback.load(ordering: .relaxed).value?(data, self)
+        self.readCallback.load(ordering: .relaxed).wrapped?(data, self)
     }
 
     /// Send web socket frame to server


### PR DESCRIPTION
- Move auto ping code into separate type and wrap in `NIOLoopBound`
- Use atomics for accessing other mutable state