### PR TITLE
Cleanup API

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         // .library(name: "HummingbirdWSCompression", targets: ["HummingbirdWSCompression"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0-beta.1"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-async-algorithms.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-http-types.git", from: "1.0.0"),

--- a/Sources/HummingbirdWebSocket/Client/WebSocketClient.swift
+++ b/Sources/HummingbirdWebSocket/Client/WebSocketClient.swift
@@ -50,7 +50,7 @@ public struct WebSocketClient {
     /// WebSocket URL
     let url: URI
     /// WebSocket data handler
-    let handler: WebSocketDataHandler<WebSocketContext>.Handler
+    let handler: WebSocketDataHandler<WebSocketContext>
     /// configuration
     let configuration: WebSocketClientConfiguration
     /// EventLoopGroup to use
@@ -75,7 +75,7 @@ public struct WebSocketClient {
         tlsConfiguration: TLSConfiguration? = nil,
         eventLoopGroup: EventLoopGroup = MultiThreadedEventLoopGroup.singleton,
         logger: Logger,
-        handler: @escaping WebSocketDataHandler<WebSocketContext>.Handler
+        handler: @escaping WebSocketDataHandler<WebSocketContext>
     ) throws {
         self.url = url
         self.handler = handler
@@ -101,7 +101,7 @@ public struct WebSocketClient {
         transportServicesTLSOptions: TSTLSOptions,
         eventLoopGroup: NIOTSEventLoopGroup = NIOTSEventLoopGroup.singleton,
         logger: Logger,
-        handler: @escaping WebSocketDataHandler<WebSocketContext>.Handler
+        handler: @escaping WebSocketDataHandler<WebSocketContext>
     ) throws {
         self.url = url
         self.handler = handler
@@ -193,7 +193,7 @@ extension WebSocketClient {
         tlsConfiguration: TLSConfiguration? = nil,
         eventLoopGroup: EventLoopGroup = MultiThreadedEventLoopGroup.singleton,
         logger: Logger,
-        handler: @escaping WebSocketDataHandler<WebSocketContext>.Handler
+        handler: @escaping WebSocketDataHandler<WebSocketContext>
     ) async throws {
         let ws = try self.init(
             url: url,
@@ -222,7 +222,7 @@ extension WebSocketClient {
         transportServicesTLSOptions: TSTLSOptions,
         eventLoopGroup: NIOTSEventLoopGroup = NIOTSEventLoopGroup.singleton,
         logger: Logger,
-        handler: @escaping WebSocketDataHandler<WebSocketContext>.Handler
+        handler: @escaping WebSocketDataHandler<WebSocketContext>
     ) async throws {
         let ws = try self.init(
             url: url,

--- a/Sources/HummingbirdWebSocket/Client/WebSocketClient.swift
+++ b/Sources/HummingbirdWebSocket/Client/WebSocketClient.swift
@@ -27,7 +27,7 @@ import ServiceLifecycle
 ///
 /// Supports TLS via both NIOSSL and Network framework.
 ///
-/// Initialize the WebSocketClient with your handler and then call ``WebSocketClient/run``
+/// Initialize the WebSocketClient with your handler and then call ``WebSocketClient/run()``
 /// to connect. The handler is provider with an `inbound` stream of WebSocket packets coming
 /// from the server and an `outbound` writer that can be used to write packets to the server.
 /// ```swift
@@ -50,7 +50,7 @@ public struct WebSocketClient {
     /// WebSocket URL
     let url: URI
     /// WebSocket data handler
-    let handler: WebSocketDataCallbackHandler
+    let handler: WebSocketDataHandler<WebSocketContext>.Handler
     /// configuration
     let configuration: WebSocketClientConfiguration
     /// EventLoopGroup to use
@@ -75,10 +75,10 @@ public struct WebSocketClient {
         tlsConfiguration: TLSConfiguration? = nil,
         eventLoopGroup: EventLoopGroup = MultiThreadedEventLoopGroup.singleton,
         logger: Logger,
-        process: @escaping WebSocketDataCallbackHandler.Callback
+        handler: @escaping WebSocketDataHandler<WebSocketContext>.Handler
     ) throws {
         self.url = url
-        self.handler = .init(process)
+        self.handler = handler
         self.configuration = configuration
         self.eventLoopGroup = eventLoopGroup
         self.logger = logger
@@ -101,10 +101,10 @@ public struct WebSocketClient {
         transportServicesTLSOptions: TSTLSOptions,
         eventLoopGroup: NIOTSEventLoopGroup = NIOTSEventLoopGroup.singleton,
         logger: Logger,
-        process: @escaping WebSocketDataCallbackHandler.Callback
+        handler: @escaping WebSocketDataHandler<WebSocketContext>.Handler
     ) throws {
         self.url = url
-        self.handler = .init(process)
+        self.handler = handler
         self.configuration = configuration
         self.eventLoopGroup = eventLoopGroup
         self.logger = logger
@@ -193,7 +193,7 @@ extension WebSocketClient {
         tlsConfiguration: TLSConfiguration? = nil,
         eventLoopGroup: EventLoopGroup = MultiThreadedEventLoopGroup.singleton,
         logger: Logger,
-        process: @escaping WebSocketDataCallbackHandler.Callback
+        handler: @escaping WebSocketDataHandler<WebSocketContext>.Handler
     ) async throws {
         let ws = try self.init(
             url: url,
@@ -201,7 +201,7 @@ extension WebSocketClient {
             tlsConfiguration: tlsConfiguration,
             eventLoopGroup: eventLoopGroup,
             logger: logger,
-            process: process
+            handler: handler
         )
         try await ws.run()
     }
@@ -222,7 +222,7 @@ extension WebSocketClient {
         transportServicesTLSOptions: TSTLSOptions,
         eventLoopGroup: NIOTSEventLoopGroup = NIOTSEventLoopGroup.singleton,
         logger: Logger,
-        process: @escaping WebSocketDataCallbackHandler.Callback
+        handler: @escaping WebSocketDataHandler<WebSocketContext>.Handler
     ) async throws {
         let ws = try self.init(
             url: url,
@@ -230,7 +230,7 @@ extension WebSocketClient {
             transportServicesTLSOptions: transportServicesTLSOptions,
             eventLoopGroup: eventLoopGroup,
             logger: logger,
-            process: process
+            handler: handler
         )
         try await ws.run()
     }

--- a/Sources/HummingbirdWebSocket/Client/WebSocketClientChannel.swift
+++ b/Sources/HummingbirdWebSocket/Client/WebSocketClientChannel.swift
@@ -29,10 +29,10 @@ struct WebSocketClientChannel: ClientConnectionChannel {
     typealias Value = EventLoopFuture<UpgradeResult>
 
     let url: String
-    let handler: WebSocketDataHandler<WebSocketContext>.Handler
+    let handler: WebSocketDataHandler<WebSocketContext>
     let configuration: WebSocketClientConfiguration
 
-    init(handler: @escaping WebSocketDataHandler<WebSocketContext>.Handler, url: String, configuration: WebSocketClientConfiguration) {
+    init(handler: @escaping WebSocketDataHandler<WebSocketContext>, url: String, configuration: WebSocketClientConfiguration) {
         self.url = url
         self.handler = handler
         self.configuration = configuration
@@ -85,8 +85,7 @@ struct WebSocketClientChannel: ClientConnectionChannel {
         switch try await value.get() {
         case .websocket(let webSocketChannel):
             let webSocket = WebSocketHandler(asyncChannel: webSocketChannel, type: .client)
-            let dataHandler = WebSocketDataHandler(context: .init(channel: webSocketChannel.channel, logger: logger), handler: self.handler)
-            await webSocket.handle(handler: dataHandler)
+            await webSocket.handle(handler: self.handler, context: WebSocketContext(channel: webSocketChannel.channel, logger: logger))
         case .notUpgraded:
             // The upgrade to websocket did not succeed.
             logger.debug("Upgrade declined")

--- a/Sources/HummingbirdWebSocket/Server/WebSocketHTTPChannelBuilder.swift
+++ b/Sources/HummingbirdWebSocket/Server/WebSocketHTTPChannelBuilder.swift
@@ -20,11 +20,11 @@ import NIOCore
 extension HTTPChannelBuilder {
     /// HTTP1 channel builder supporting a websocket upgrade
     ///  - parameters
-    public static func webSocketUpgrade<Handler: WebSocketDataHandler>(
+    public static func webSocketUpgrade(
         configuration: WebSocketServerConfiguration = .init(),
         additionalChannelHandlers: @autoclosure @escaping @Sendable () -> [any RemovableChannelHandler] = [],
-        shouldUpgrade: @escaping @Sendable (HTTPRequest, Channel, Logger) async throws -> ShouldUpgradeResult<Handler>
-    ) -> HTTPChannelBuilder<HTTP1AndWebSocketChannel<Handler>> {
+        shouldUpgrade: @escaping @Sendable (HTTPRequest, Channel, Logger) async throws -> ShouldUpgradeResult<WebSocketDataHandler<WebSocketContext>.Handler>
+    ) -> HTTPChannelBuilder<HTTP1AndWebSocketChannel<WebSocketContext>> {
         return .init { responder in
             return HTTP1AndWebSocketChannel(
                 responder: responder,
@@ -36,13 +36,13 @@ extension HTTPChannelBuilder {
     }
 
     /// HTTP1 channel builder supporting a websocket upgrade
-    public static func webSocketUpgrade<Handler: WebSocketDataHandler>(
+    public static func webSocketUpgrade(
         configuration: WebSocketServerConfiguration = .init(),
         additionalChannelHandlers: @autoclosure @escaping @Sendable () -> [any RemovableChannelHandler] = [],
-        shouldUpgrade: @escaping @Sendable (HTTPRequest, Channel, Logger) throws -> ShouldUpgradeResult<Handler>
-    ) -> HTTPChannelBuilder<HTTP1AndWebSocketChannel<Handler>> {
+        shouldUpgrade: @escaping @Sendable (HTTPRequest, Channel, Logger) throws -> ShouldUpgradeResult<WebSocketDataHandler<WebSocketContext>.Handler>
+    ) -> HTTPChannelBuilder<HTTP1AndWebSocketChannel<WebSocketContext>> {
         return .init { responder in
-            return HTTP1AndWebSocketChannel<Handler>(
+            return HTTP1AndWebSocketChannel(
                 responder: responder,
                 configuration: configuration,
                 additionalChannelHandlers: additionalChannelHandlers,

--- a/Sources/HummingbirdWebSocket/Server/WebSocketHTTPChannelBuilder.swift
+++ b/Sources/HummingbirdWebSocket/Server/WebSocketHTTPChannelBuilder.swift
@@ -23,7 +23,7 @@ extension HTTPChannelBuilder {
     public static func webSocketUpgrade(
         configuration: WebSocketServerConfiguration = .init(),
         additionalChannelHandlers: @autoclosure @escaping @Sendable () -> [any RemovableChannelHandler] = [],
-        shouldUpgrade: @escaping @Sendable (HTTPRequest, Channel, Logger) async throws -> ShouldUpgradeResult<WebSocketDataHandler<WebSocketContext>.Handler>
+        shouldUpgrade: @escaping @Sendable (HTTPRequest, Channel, Logger) async throws -> ShouldUpgradeResult<WebSocketDataHandler<WebSocketContext>>
     ) -> HTTPChannelBuilder<HTTP1AndWebSocketChannel<WebSocketContext>> {
         return .init { responder in
             return HTTP1AndWebSocketChannel(
@@ -39,7 +39,7 @@ extension HTTPChannelBuilder {
     public static func webSocketUpgrade(
         configuration: WebSocketServerConfiguration = .init(),
         additionalChannelHandlers: @autoclosure @escaping @Sendable () -> [any RemovableChannelHandler] = [],
-        shouldUpgrade: @escaping @Sendable (HTTPRequest, Channel, Logger) throws -> ShouldUpgradeResult<WebSocketDataHandler<WebSocketContext>.Handler>
+        shouldUpgrade: @escaping @Sendable (HTTPRequest, Channel, Logger) throws -> ShouldUpgradeResult<WebSocketDataHandler<WebSocketContext>>
     ) -> HTTPChannelBuilder<HTTP1AndWebSocketChannel<WebSocketContext>> {
         return .init { responder in
             return HTTP1AndWebSocketChannel(

--- a/Sources/HummingbirdWebSocket/Server/WebSocketHTTPChannelBuilder.swift
+++ b/Sources/HummingbirdWebSocket/Server/WebSocketHTTPChannelBuilder.swift
@@ -24,7 +24,7 @@ extension HTTPChannelBuilder {
         configuration: WebSocketServerConfiguration = .init(),
         additionalChannelHandlers: @autoclosure @escaping @Sendable () -> [any RemovableChannelHandler] = [],
         shouldUpgrade: @escaping @Sendable (HTTPRequest, Channel, Logger) async throws -> ShouldUpgradeResult<WebSocketDataHandler<WebSocketContext>>
-    ) -> HTTPChannelBuilder<HTTP1AndWebSocketChannel<WebSocketContext>> {
+    ) -> HTTPChannelBuilder<HTTP1AndWebSocketChannel> {
         return .init { responder in
             return HTTP1AndWebSocketChannel(
                 responder: responder,
@@ -40,7 +40,7 @@ extension HTTPChannelBuilder {
         configuration: WebSocketServerConfiguration = .init(),
         additionalChannelHandlers: @autoclosure @escaping @Sendable () -> [any RemovableChannelHandler] = [],
         shouldUpgrade: @escaping @Sendable (HTTPRequest, Channel, Logger) throws -> ShouldUpgradeResult<WebSocketDataHandler<WebSocketContext>>
-    ) -> HTTPChannelBuilder<HTTP1AndWebSocketChannel<WebSocketContext>> {
+    ) -> HTTPChannelBuilder<HTTP1AndWebSocketChannel> {
         return .init { responder in
             return HTTP1AndWebSocketChannel(
                 responder: responder,

--- a/Sources/HummingbirdWebSocket/Server/WebSocketRouter.swift
+++ b/Sources/HummingbirdWebSocket/Server/WebSocketRouter.swift
@@ -141,7 +141,7 @@ extension HTTP1AndWebSocketChannel {
                 do {
                     let response = try await webSocketResponder.respond(to: request, context: context)
                     if response.status == .ok, let webSocketHandler = context.webSocket.handler.withLockedValue({ $0 }) {
-                        return .upgrade(response.headers) { asyncChannel in
+                        return .upgrade(response.headers) { asyncChannel, _ in
                             let webSocket = WebSocketHandler(asyncChannel: asyncChannel, type: .server)
                             await webSocket.handle(handler: webSocketHandler.handler, context: webSocketHandler.context)
                         }

--- a/Sources/HummingbirdWebSocket/Server/WebSocketRouter.swift
+++ b/Sources/HummingbirdWebSocket/Server/WebSocketRouter.swift
@@ -23,23 +23,23 @@ import NIOCore
 /// WebSocket Router context type.
 ///
 /// Includes reference to optional websocket handler
-public struct WebSocketRouterContext: Sendable {
+public struct WebSocketRouterContext<Context: WebSocketRequestContext>: Sendable {
     public init() {
         self.handler = .init(nil)
     }
 
-    let handler: NIOLockedValueBox<WebSocketDataCallbackHandler?>
+    let handler: NIOLockedValueBox<WebSocketDataHandler<Context>?>
 }
 
 /// Request context protocol requirement for routers that support websockets
 public protocol WebSocketRequestContext: RequestContext, WebSocketContextProtocol {
-    var webSocket: WebSocketRouterContext { get }
+    var webSocket: WebSocketRouterContext<Self> { get }
 }
 
 /// Default implementation of a request context that supports WebSockets
 public struct BasicWebSocketRequestContext: WebSocketRequestContext {
     public var coreContext: CoreRequestContext
-    public let webSocket: WebSocketRouterContext
+    public let webSocket: WebSocketRouterContext<Self>
 
     public init(channel: Channel, logger: Logger) {
         self.coreContext = .init(allocator: channel.allocator, logger: logger)
@@ -63,7 +63,7 @@ extension RouterMethods {
     @discardableResult public func ws(
         _ path: String = "",
         shouldUpgrade: @Sendable @escaping (Request, Context) async throws -> RouterShouldUpgrade = { _, _ in .upgrade([:]) },
-        handle: @escaping WebSocketDataCallbackHandler.Callback
+        handle: @escaping WebSocketDataHandler<Context>.Handler
     ) -> Self where Context: WebSocketRequestContext {
         return on(path, method: .get) { request, context -> Response in
             let result = try await shouldUpgrade(request, context)
@@ -71,7 +71,7 @@ extension RouterMethods {
             case .dontUpgrade:
                 return .init(status: .methodNotAllowed)
             case .upgrade(let headers):
-                context.webSocket.handler.withLockedValue { $0 = WebSocketDataCallbackHandler(handle) }
+                context.webSocket.handler.withLockedValue { $0 = WebSocketDataHandler(context: context, handler: handle) }
                 return .init(status: .ok, headers: headers)
             }
         }
@@ -84,7 +84,7 @@ extension RouterMethods {
 /// with ``Hummingbird/Router`` if you add a route immediately after it.
 public struct WebSocketUpgradeMiddleware<Context: WebSocketRequestContext>: RouterMiddleware {
     let shouldUpgrade: @Sendable (Request, Context) async throws -> RouterShouldUpgrade
-    let handle: WebSocketDataCallbackHandler.Callback
+    let handler: WebSocketDataHandler<Context>.Handler
 
     /// Initialize WebSocketUpgradeMiddleare
     /// - Parameters:
@@ -92,10 +92,10 @@ public struct WebSocketUpgradeMiddleware<Context: WebSocketRequestContext>: Rout
     ///   - handle: WebSocket handler
     public init(
         shouldUpgrade: @Sendable @escaping (Request, Context) async throws -> RouterShouldUpgrade = { _, _ in .upgrade([:]) },
-        handle: @escaping WebSocketDataCallbackHandler.Callback
+        handler: @escaping WebSocketDataHandler<Context>.Handler
     ) {
         self.shouldUpgrade = shouldUpgrade
-        self.handle = handle
+        self.handler = handler
     }
 
     /// WebSocketUpgradeMiddleware handler
@@ -105,13 +105,13 @@ public struct WebSocketUpgradeMiddleware<Context: WebSocketRequestContext>: Rout
         case .dontUpgrade:
             return .init(status: .methodNotAllowed)
         case .upgrade(let headers):
-            context.webSocket.handler.withLockedValue { $0 = WebSocketDataCallbackHandler(self.handle) }
+            context.webSocket.handler.withLockedValue { $0 = .init(context: context, handler: self.handler) }
             return .init(status: .ok, headers: headers)
         }
     }
 }
 
-extension HTTP1AndWebSocketChannel {
+extension HTTP1AndWebSocketChannel where Context: WebSocketRequestContext {
     ///  Initialize HTTP1AndWebSocketChannel with async `shouldUpgrade` function
     /// - Parameters:
     ///   - additionalChannelHandlers: Additional channel handlers to add
@@ -119,26 +119,33 @@ extension HTTP1AndWebSocketChannel {
     ///   - maxFrameSize: Max frame size WebSocket will allow
     ///   - webSocketRouter: WebSocket router
     /// - Returns: Upgrade result future
-    public init<Context: WebSocketRequestContext, WSResponder: HTTPResponder>(
+    public init<WSResponder: HTTPResponder>(
         responder: @escaping @Sendable (Request, Channel) async throws -> Response,
         webSocketResponder: WSResponder,
         configuration: WebSocketServerConfiguration,
         additionalChannelHandlers: @escaping @Sendable () -> [any RemovableChannelHandler] = { [] }
-    ) where Handler == WebSocketDataCallbackHandler, WSResponder.Context == Context {
-        self.init(responder: responder, configuration: configuration, additionalChannelHandlers: additionalChannelHandlers) { head, channel, logger in
-            let request = Request(head: head, body: .init(buffer: .init()))
-            let context = Context(channel: channel, logger: logger.with(metadataKey: "hb_id", value: .stringConvertible(RequestID())))
-            do {
-                let response = try await webSocketResponder.respond(to: request, context: context)
-                if response.status == .ok, let webSocketHandler = context.webSocket.handler.withLockedValue({ $0 }) {
-                    return .upgrade(response.headers, webSocketHandler)
-                } else {
+    ) where WSResponder.Context == Context {
+        self.additionalChannelHandlers = additionalChannelHandlers
+        self.configuration = configuration
+        self.shouldUpgrade = { head, channel, logger in
+            let promise = channel.eventLoop.makePromise(of: ShouldUpgradeResult<WebSocketDataHandler<Context>>.self)
+            promise.completeWithTask {
+                let request = Request(head: head, body: .init(buffer: .init()))
+                let context = Context(channel: channel, logger: logger.with(metadataKey: "hb_id", value: .stringConvertible(RequestID())))
+                do {
+                    let response = try await webSocketResponder.respond(to: request, context: context)
+                    if response.status == .ok, let webSocketHandler = context.webSocket.handler.withLockedValue({ $0 }) {
+                        return .upgrade(response.headers, webSocketHandler)
+                    } else {
+                        return .dontUpgrade
+                    }
+                } catch {
                     return .dontUpgrade
                 }
-            } catch {
-                return .dontUpgrade
             }
+            return promise.futureResult
         }
+        self.responder = responder
     }
 }
 
@@ -158,7 +165,7 @@ extension HTTPChannelBuilder {
         webSocketRouter: WSResponderBuilder,
         configuration: WebSocketServerConfiguration = .init(),
         additionalChannelHandlers: @autoclosure @escaping @Sendable () -> [any RemovableChannelHandler] = []
-    ) -> HTTPChannelBuilder<HTTP1AndWebSocketChannel<WebSocketDataCallbackHandler>> where WSResponderBuilder.Responder.Context: WebSocketRequestContext {
+    ) -> HTTPChannelBuilder<HTTP1AndWebSocketChannel<WSResponderBuilder.Responder.Context>> where WSResponderBuilder.Responder.Context: WebSocketRequestContext {
         let webSocketReponder = webSocketRouter.buildResponder()
         return .init { responder in
             return HTTP1AndWebSocketChannel(
@@ -182,29 +189,4 @@ extension Logger {
         logger[metadataKey: metadataKey] = value
         return logger
     }
-}
-
-/// Generate Unique ID for each request. This is a duplicate of the RequestID in Hummingbird
-package struct RequestID: CustomStringConvertible {
-    let low: UInt64
-
-    package init() {
-        self.low = Self.globalRequestID.loadThenWrappingIncrement(by: 1, ordering: .relaxed)
-    }
-
-    package var description: String {
-        Self.high + self.formatAsHexWithLeadingZeros(self.low)
-    }
-
-    func formatAsHexWithLeadingZeros(_ value: UInt64) -> String {
-        let string = String(value, radix: 16)
-        if string.count < 16 {
-            return String(repeating: "0", count: 16 - string.count) + string
-        } else {
-            return string
-        }
-    }
-
-    private static let high = String(UInt64.random(in: .min ... .max), radix: 16)
-    private static let globalRequestID = ManagedAtomic<UInt64>(UInt64.random(in: .min ... .max))
 }

--- a/Sources/HummingbirdWebSocket/WebSocketDataHandler.swift
+++ b/Sources/HummingbirdWebSocket/WebSocketDataHandler.swift
@@ -18,20 +18,17 @@ import Logging
 import NIOCore
 import NIOWebSocket
 
-/// Protocol for web socket data handling
-///
-/// This is the users interface into HummingbirdWebSocket. They provide an implementation of this protocol when
-/// contructing their WebSocket upgrade handler. The user needs to return a type conforming to this protocol in
-/// the `shouldUpgrade` closure in HTTP1AndWebSocketChannel.init
-public struct WebSocketDataHandler<Context: WebSocketContextProtocol>: Sendable {
-    /// Handler closure type
-    public typealias Handler = @Sendable (WebSocketHandlerInbound, WebSocketHandlerOutboundWriter, Context) async throws -> Void
+/// Handle websocket data and text blocks
+public typealias WebSocketDataHandler<Context: WebSocketContextProtocol> = @Sendable (WebSocketHandlerInbound, WebSocketHandlerOutboundWriter, Context) async throws -> Void
+
+/// Struct holding for web socket data handler and context.
+public struct WebSocketDataHandlerAndContext<Context: WebSocketContextProtocol>: Sendable {
     /// Context sent to handler
     let context: Context
     /// handler function
-    let handler: Handler
+    let handler: WebSocketDataHandler<Context>
 
-    public init(context: Context, handler: @escaping Handler) {
+    public init(context: Context, handler: @escaping WebSocketDataHandler<Context>) {
         self.context = context
         self.handler = handler
     }

--- a/Sources/HummingbirdWebSocket/WebSocketDataHandler.swift
+++ b/Sources/HummingbirdWebSocket/WebSocketDataHandler.swift
@@ -18,22 +18,5 @@ import Logging
 import NIOCore
 import NIOWebSocket
 
-/// Handle websocket data and text blocks
+/// Function that handles websocket data and text blocks
 public typealias WebSocketDataHandler<Context: WebSocketContextProtocol> = @Sendable (WebSocketHandlerInbound, WebSocketHandlerOutboundWriter, Context) async throws -> Void
-
-/// Struct holding for web socket data handler and context.
-public struct WebSocketDataHandlerAndContext<Context: WebSocketContextProtocol>: Sendable {
-    /// Context sent to handler
-    let context: Context
-    /// handler function
-    let handler: WebSocketDataHandler<Context>
-
-    public init(context: Context, handler: @escaping WebSocketDataHandler<Context>) {
-        self.context = context
-        self.handler = handler
-    }
-
-    func withContext(channel: Channel, logger: Logger) -> Self {
-        .init(context: .init(channel: channel, logger: logger), handler: self.handler)
-    }
-}

--- a/Sources/HummingbirdWebSocket/WebSocketHandler.swift
+++ b/Sources/HummingbirdWebSocket/WebSocketHandler.swift
@@ -41,10 +41,8 @@ actor WebSocketHandler: Sendable {
     }
 
     /// Handle WebSocket AsynChannel
-    func handle<Handler: WebSocketDataHandler>(
-        handler: Handler,
-        context: Handler.Context
-    ) async {
+    func handle(handler: WebSocketDataHandler<some WebSocketContextProtocol>) async {
+        let context = handler.context
         try? await self.asyncChannel.executeThenClose { inbound, outbound in
             do {
                 try await withThrowingTaskGroup(of: Void.self) { group in
@@ -90,7 +88,7 @@ actor WebSocketHandler: Sendable {
                     }
                     group.addTask {
                         // handle websocket data and text
-                        try await handler.handle(webSocketHandlerInbound, webSocketHandlerOutbound, context: context)
+                        try await handler.handler(webSocketHandlerInbound, webSocketHandlerOutbound, context)
                         try await self.close(code: .normalClosure, outbound: outbound, context: context)
                     }
                     try await group.next()

--- a/Sources/HummingbirdWebSocket/WebSocketHandler.swift
+++ b/Sources/HummingbirdWebSocket/WebSocketHandler.swift
@@ -41,8 +41,7 @@ actor WebSocketHandler: Sendable {
     }
 
     /// Handle WebSocket AsynChannel
-    func handle(handler: WebSocketDataHandler<some WebSocketContextProtocol>) async {
-        let context = handler.context
+    func handle<Context: WebSocketContextProtocol>(handler: @escaping WebSocketDataHandler<Context>, context: Context) async {
         try? await self.asyncChannel.executeThenClose { inbound, outbound in
             do {
                 try await withThrowingTaskGroup(of: Void.self) { group in
@@ -88,7 +87,7 @@ actor WebSocketHandler: Sendable {
                     }
                     group.addTask {
                         // handle websocket data and text
-                        try await handler.handler(webSocketHandlerInbound, webSocketHandlerOutbound, context)
+                        try await handler(webSocketHandlerInbound, webSocketHandlerOutbound, context)
                         try await self.close(code: .normalClosure, outbound: outbound, context: context)
                     }
                     try await group.next()

--- a/Tests/HummingbirdWebSocketTests/WebSocketTests.swift
+++ b/Tests/HummingbirdWebSocketTests/WebSocketTests.swift
@@ -76,7 +76,7 @@ final class HummingbirdWebSocketTests: XCTestCase {
 
     func testClientAndServer(
         serverTLSConfiguration: TLSConfiguration? = nil,
-        server serverHandler: @escaping WebSocketDataHandler<WebSocketContext>.Handler,
+        server serverHandler: @escaping WebSocketDataHandler<WebSocketContext>,
         shouldUpgrade: @escaping @Sendable (HTTPRequest) throws -> HTTPFields? = { _ in return [:] },
         getClient: @escaping @Sendable (Int, Logger) throws -> WebSocketClient
     ) async throws {
@@ -144,9 +144,9 @@ final class HummingbirdWebSocketTests: XCTestCase {
 
     func testClientAndServer(
         serverTLSConfiguration: TLSConfiguration? = nil,
-        server serverHandler: @escaping WebSocketDataHandler<WebSocketContext>.Handler,
+        server serverHandler: @escaping WebSocketDataHandler<WebSocketContext>,
         shouldUpgrade: @escaping @Sendable (HTTPRequest) throws -> HTTPFields? = { _ in return [:] },
-        client clientHandler: @escaping WebSocketDataHandler<WebSocketContext>.Handler
+        client clientHandler: @escaping WebSocketDataHandler<WebSocketContext>
     ) async throws {
         try await self.testClientAndServer(
             serverTLSConfiguration: serverTLSConfiguration,

--- a/Tests/HummingbirdWebSocketTests/WebSocketTests.swift
+++ b/Tests/HummingbirdWebSocketTests/WebSocketTests.swift
@@ -393,12 +393,12 @@ final class HummingbirdWebSocketTests: XCTestCase {
         let router = Router(context: BasicWebSocketRequestContext.self)
         router.ws("/ws1") { _, _ in
             return .upgrade([:])
-        } handle: { _, outbound, _ in
+        } onUpgrade: { _, outbound, _ in
             try await outbound.write(.text("One"))
         }
         router.ws("/ws2") { _, _ in
             return .upgrade([:])
-        } handle: { _, outbound, _ in
+        } onUpgrade: { _, outbound, _ in
             try await outbound.write(.text("Two"))
         }
         try await self.testClientAndServerWithRouter(webSocketRouter: router, uri: "localhost:8080") { port, logger in
@@ -422,7 +422,7 @@ final class HummingbirdWebSocketTests: XCTestCase {
         router.group("/ws")
             .add(middleware: WebSocketUpgradeMiddleware { _, _ in
                 return .upgrade([:])
-            } handler: { _, outbound, _ in
+            } onUpgrade: { _, outbound, _ in
                 try await outbound.write(.text("One"))
             })
             .get { _, _ -> Response in return .init(status: .ok) }
@@ -437,7 +437,7 @@ final class HummingbirdWebSocketTests: XCTestCase {
         let router = Router(context: BasicWebSocketRequestContext.self)
         router.ws("/ws") { _, _ in
             return .upgrade([:])
-        } handle: { _, outbound, _ in
+        } onUpgrade: { _, outbound, _ in
             try await outbound.write(.text("One"))
         }
         do {
@@ -471,7 +471,7 @@ final class HummingbirdWebSocketTests: XCTestCase {
         router.middlewares.add(MyMiddleware())
         router.ws("/ws") { _, _ in
             return .upgrade([:])
-        } handle: { _, outbound, context in
+        } onUpgrade: { _, outbound, context in
             try await outbound.write(.text(context.name))
         }
         do {
@@ -488,7 +488,7 @@ final class HummingbirdWebSocketTests: XCTestCase {
         let router = Router(context: BasicWebSocketRequestContext.self)
         router.ws("/ws") { _, _ in
             return .upgrade([:])
-        } handle: { _, outbound, _ in
+        } onUpgrade: { _, outbound, _ in
             try await outbound.write(.text("Hello"))
         }
         router.get("/http") { _, _ in


### PR DESCRIPTION
- WebSocketDataHandler is no longer a protocol, it is just a closure
- Removed generic parameters from `WebSocketClientChannel` and `HTTP1AndWebSocketChannel`