### PR TITLE
Wrap WebSocketFrame inbound iterator

### DIFF
--- a/Sources/HummingbirdWebSocket/Client/WebSocketClientChannel.swift
+++ b/Sources/HummingbirdWebSocket/Client/WebSocketClientChannel.swift
@@ -92,8 +92,13 @@ struct WebSocketClientChannel: ClientConnectionChannel {
     func handle(value: Value, logger: Logger) async throws {
         switch try await value.get() {
         case .websocket(let webSocketChannel, let extensions):
-            let webSocket = WebSocketHandler(asyncChannel: webSocketChannel, type: .client, extensions: extensions)
-            await webSocket.handle(handler: self.handler, context: WebSocketContext(channel: webSocketChannel.channel, logger: logger))
+            await WebSocketHandler.handle(
+                type: .client,
+                extensions: extensions,
+                asyncChannel: webSocketChannel,
+                context: WebSocketContext(channel: webSocketChannel.channel, logger: logger),
+                handler: self.handler
+            )
         case .notUpgraded:
             // The upgrade to websocket did not succeed.
             logger.debug("Upgrade declined")

--- a/Sources/HummingbirdWebSocket/Server/WebSocketChannel.swift
+++ b/Sources/HummingbirdWebSocket/Server/WebSocketChannel.swift
@@ -61,9 +61,14 @@ public struct HTTP1WebSocketUpgradeChannel: ServerChildChannel, HTTPChannelHandl
                             logger: logger
                         )
                         return (headers, { asyncChannel, logger in
-                            let webSocket = WebSocketHandler(asyncChannel: asyncChannel, type: .server, extensions: extensions)
                             let context = WebSocketContext(channel: channel, logger: logger)
-                            await webSocket.handle(handler: handler, context: context)
+                            await WebSocketHandler.handle(
+                                type: .server,
+                                extensions: extensions,
+                                asyncChannel: asyncChannel,
+                                context: context,
+                                handler: handler
+                            )
                         })
                     }
             }
@@ -98,9 +103,14 @@ public struct HTTP1WebSocketUpgradeChannel: ServerChildChannel, HTTPChannelHandl
                             logger: logger
                         )
                         return (headers, { asyncChannel, logger in
-                            let webSocket = WebSocketHandler(asyncChannel: asyncChannel, type: .server, extensions: extensions)
                             let context = WebSocketContext(channel: channel, logger: logger)
-                            await webSocket.handle(handler: handler, context: context)
+                            await WebSocketHandler.handle(
+                                type: .server,
+                                extensions: extensions,
+                                asyncChannel: asyncChannel,
+                                context: context,
+                                handler: handler
+                            )
                         })
                     }
             }

--- a/Sources/HummingbirdWebSocket/Server/WebSocketRouter.swift
+++ b/Sources/HummingbirdWebSocket/Server/WebSocketRouter.swift
@@ -148,8 +148,13 @@ extension HTTP1WebSocketUpgradeChannel {
                             logger: logger
                         )
                         return .upgrade(headers) { asyncChannel, _ in
-                            let webSocket = WebSocketHandler(asyncChannel: asyncChannel, type: .server, extensions: extensions)
-                            await webSocket.handle(handler: webSocketHandler.handler, context: webSocketHandler.context)
+                            await WebSocketHandler.handle(
+                                type: .server,
+                                extensions: extensions,
+                                asyncChannel: asyncChannel,
+                                context: webSocketHandler.context,
+                                handler: webSocketHandler.handler
+                            )
                         }
                     } else {
                         return .dontUpgrade

--- a/Sources/HummingbirdWebSocket/UnsafeTransfer.swift
+++ b/Sources/HummingbirdWebSocket/UnsafeTransfer.swift
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2024 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2021-2022 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// ``UnsafeTransfer`` can be used to make non-`Sendable` values `Sendable`.
+/// As the name implies, the usage of this is unsafe because it disables the sendable checking of the compiler.
+/// It can be used similar to `@unsafe Sendable` but for values instead of types.
+@usableFromInline
+struct UnsafeTransfer<Wrapped> {
+    @usableFromInline
+    var wrappedValue: Wrapped
+
+    @inlinable
+    init(_ wrappedValue: Wrapped) {
+        self.wrappedValue = wrappedValue
+    }
+}
+
+extension UnsafeTransfer: @unchecked Sendable {}
+
+extension UnsafeTransfer: Equatable where Wrapped: Equatable {}
+extension UnsafeTransfer: Hashable where Wrapped: Hashable {}
+
+/// ``UnsafeMutableTransferBox`` can be used to make non-`Sendable` values `Sendable` and mutable.
+/// It can be used to capture local mutable values in a `@Sendable` closure and mutate them from within the closure.
+/// As the name implies, the usage of this is unsafe because it disables the sendable checking of the compiler and does not add any synchronisation.
+@usableFromInline
+final class UnsafeMutableTransferBox<Wrapped> {
+    @usableFromInline
+    var wrappedValue: Wrapped
+
+    @inlinable
+    init(_ wrappedValue: Wrapped) {
+        self.wrappedValue = wrappedValue
+    }
+}
+
+extension UnsafeMutableTransferBox: @unchecked Sendable {}

--- a/Sources/HummingbirdWebSocket/WebSocketContext.swift
+++ b/Sources/HummingbirdWebSocket/WebSocketContext.swift
@@ -31,4 +31,9 @@ public struct WebSocketContext: WebSocketContextProtocol {
         self.logger = logger
         self.allocator = channel.allocator
     }
+
+    init(allocator: ByteBufferAllocator, logger: Logger) {
+        self.allocator = allocator
+        self.logger = logger
+    }
 }

--- a/Sources/HummingbirdWebSocket/WebSocketDataFrame.swift
+++ b/Sources/HummingbirdWebSocket/WebSocketDataFrame.swift
@@ -1,0 +1,60 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2023-2024 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+import NIOWebSocket
+
+/// Enumeration holding WebSocket data
+public enum WebSocketDataFrame: Equatable, Sendable, CustomStringConvertible, CustomDebugStringConvertible {
+    case text(String)
+    case binary(ByteBuffer)
+
+    init?(frame: WebSocketFrame) {
+        switch frame.opcode {
+        case .text:
+            self = .text(String(buffer: frame.unmaskedData))
+        case .binary:
+            self = .binary(frame.unmaskedData)
+        default:
+            return nil
+        }
+    }
+
+    public var webSocketFrame: WebSocketFrame {
+        switch self {
+        case .text(let string):
+            return .init(fin: true, opcode: .text, data: ByteBuffer(string: string))
+        case .binary(let buffer):
+            return .init(fin: true, opcode: .binary, data: buffer)
+        }
+    }
+
+    public var description: String {
+        switch self {
+        case .text(let string):
+            return "string(\"\(string)\")"
+        case .binary(let buffer):
+            return "binary(\(buffer.description))"
+        }
+    }
+
+    public var debugDescription: String {
+        switch self {
+        case .text(let string):
+            return "string(\"\(string)\")"
+        case .binary(let buffer):
+            return "binary(\(buffer.debugDescription))"
+        }
+    }
+}

--- a/Sources/HummingbirdWebSocket/WebSocketDataHandler.swift
+++ b/Sources/HummingbirdWebSocket/WebSocketDataHandler.swift
@@ -19,4 +19,4 @@ import NIOCore
 import NIOWebSocket
 
 /// Function that handles websocket data and text blocks
-public typealias WebSocketDataHandler<Context: WebSocketContextProtocol> = @Sendable (WebSocketInboundStream, WebSocketOutboundWriter<Context>, Context) async throws -> Void
+public typealias WebSocketDataHandler<Context: WebSocketContextProtocol> = @Sendable (WebSocketInboundStream, WebSocketOutboundWriter, Context) async throws -> Void

--- a/Sources/HummingbirdWebSocket/WebSocketHandler.swift
+++ b/Sources/HummingbirdWebSocket/WebSocketHandler.swift
@@ -86,7 +86,7 @@ actor WebSocketHandler {
         let webSocketOutbound = WebSocketOutboundWriter(handler: self)
         var inboundIterator = inbound.makeAsyncIterator()
         let webSocketInbound = WebSocketInboundStream(
-            inboundIterator: inboundIterator,
+            iterator: inboundIterator,
             handler: self
         )
         try? await withGracefulShutdownHandler {

--- a/Sources/HummingbirdWebSocket/WebSocketHandler.swift
+++ b/Sources/HummingbirdWebSocket/WebSocketHandler.swift
@@ -28,124 +28,48 @@ public enum WebSocketType: Sendable {
 ///
 /// Manages ping, pong and close messages. Collates data and text messages into final frame
 /// and passes them onto the ``WebSocketDataHandler`` data handler setup by the user.
-actor WebSocketHandler: Sendable {
+actor WebSocketHandler {
     enum InternalError: Error {
         case close(WebSocketErrorCode)
     }
 
     static let pingDataSize = 16
-
-    let asyncChannel: NIOAsyncChannel<WebSocketFrame, WebSocketFrame>
+    var outbound: NIOAsyncChannelOutboundWriter<WebSocketFrame>
     let type: WebSocketType
+    let extensions: [any WebSocketExtension]
+    let context: WebSocketContext
     var pingData: ByteBuffer
     var closed = false
-    let extensions: [any WebSocketExtension]
 
-    init(asyncChannel: NIOAsyncChannel<WebSocketFrame, WebSocketFrame>, type: WebSocketType, extensions: [any WebSocketExtension]) {
-        self.asyncChannel = asyncChannel
+    private init(
+        outbound: NIOAsyncChannelOutboundWriter<WebSocketFrame>,
+        type: WebSocketType,
+        extensions: [any WebSocketExtension],
+        context: some WebSocketContextProtocol
+    ) {
+        self.outbound = outbound
         self.type = type
+        self.extensions = extensions
+        self.context = .init(allocator: context.allocator, logger: context.logger)
         self.pingData = ByteBufferAllocator().buffer(capacity: Self.pingDataSize)
         self.closed = false
-        self.extensions = extensions
     }
 
-    /// Handle WebSocket AsynChannel
-    func handle<Context: WebSocketContextProtocol>(handler: @escaping WebSocketDataHandler<Context>, context: Context) async {
-        let asyncChannel = self.asyncChannel
+    static func handle<Context: WebSocketContextProtocol>(
+        type: WebSocketType,
+        extensions: [any WebSocketExtension],
+        asyncChannel: NIOAsyncChannel<WebSocketFrame, WebSocketFrame>,
+        context: Context,
+        handler: @escaping WebSocketDataHandler<Context>
+    ) async {
         try? await asyncChannel.executeThenClose { inbound, outbound in
-            let webSocketInbound = WebSocketInboundStream()
-            let webSocketOutbound = WebSocketOutboundWriter(
-                type: self.type,
-                allocator: asyncChannel.channel.allocator,
-                outbound: outbound,
-                extensions: self.extensions,
-                context: context
-            )
-            try await withTaskCancellationHandler {
-                try await withGracefulShutdownHandler {
-                    try await withThrowingTaskGroup(of: Void.self) { group in
-                        group.addTask {
-                            defer {
-                                webSocketInbound.finish()
-                            }
-                            // parse messages coming from inbound
-                            var frameSequence: WebSocketFrameSequence?
-                            for try await frame in inbound {
-                                do {
-                                    context.logger.trace("Received \(frame.opcode)")
-                                    switch frame.opcode {
-                                    case .connectionClose:
-                                        // we received a connection close. Finish the inbound data stream,
-                                        // send a close back if it hasn't already been send and exit
-                                        webSocketInbound.finish()
-                                        _ = try await self.close(code: .normalClosure, outbound: webSocketOutbound, context: context)
-                                        return
-                                    case .ping:
-                                        try await self.onPing(frame, outbound: webSocketOutbound, context: context)
-                                    case .pong:
-                                        try await self.onPong(frame, outbound: webSocketOutbound, context: context)
-                                    case .text, .binary:
-                                        if var frameSeq = frameSequence {
-                                            frameSeq.append(frame)
-                                            frameSequence = frameSeq
-                                        } else {
-                                            frameSequence = WebSocketFrameSequence(frame: frame)
-                                        }
-                                    case .continuation:
-                                        if var frameSeq = frameSequence {
-                                            frameSeq.append(frame)
-                                            frameSequence = frameSeq
-                                        } else {
-                                            try await self.close(code: .protocolError, outbound: webSocketOutbound, context: context)
-                                        }
-                                    default:
-                                        break
-                                    }
-                                    if let frameSeq = frameSequence, frame.fin {
-                                        var collatedFrame = frameSeq.collapsed
-                                        for ext in self.extensions.reversed() {
-                                            collatedFrame = try await ext.processReceivedFrame(collatedFrame, context: context)
-                                        }
-                                        if let finalFrame = WebSocketDataFrame(frame: collatedFrame) {
-                                            await webSocketInbound.send(finalFrame)
-                                            frameSequence = nil
-                                        }
-                                    }
-                                } catch {
-                                    // catch errors while processing websocket frames so responding close message
-                                    // can be dealt with
-                                    let errorCode = WebSocketErrorCode(error)
-                                    try await self.close(code: errorCode, outbound: webSocketOutbound, context: context)
-                                }
-                            }
-                        }
-                        group.addTask {
-                            do {
-                                // handle websocket data and text
-                                try await handler(webSocketInbound, webSocketOutbound, context)
-                                try await self.close(code: .normalClosure, outbound: webSocketOutbound, context: context)
-                            } catch InternalError.close(let code) {
-                                try await self.close(code: code, outbound: webSocketOutbound, context: context)
-                            } catch {
-                                if self.type == .server {
-                                    let errorCode = WebSocketErrorCode.unexpectedServerError
-                                    try await self.close(code: errorCode, outbound: webSocketOutbound, context: context)
-                                } else {
-                                    try await asyncChannel.channel.close(mode: .input)
-                                }
-                            }
-                        }
-                        try await group.next()
-                        webSocketInbound.finish()
-                    }
-                } onGracefulShutdown: {
-                    Task {
-                        try? await self.close(code: .normalClosure, outbound: webSocketOutbound, context: context)
-                    }
+            await withTaskCancellationHandler {
+                await withThrowingTaskGroup(of: Void.self) { _ in
+                    let webSocketHandler = Self(outbound: outbound, type: type, extensions: extensions, context: context)
+                    await webSocketHandler.handle(inbound: inbound, outbound: outbound, handler: handler, context: context)
                 }
             } onCancel: {
                 Task {
-                    webSocketInbound.finish()
                     try await asyncChannel.channel.close(mode: .input)
                 }
             }
@@ -153,68 +77,236 @@ actor WebSocketHandler: Sendable {
         context.logger.debug("Closed WebSocket")
     }
 
+    func handle<Context: WebSocketContextProtocol>(
+        inbound: NIOAsyncChannelInboundStream<WebSocketFrame>,
+        outbound: NIOAsyncChannelOutboundWriter<WebSocketFrame>,
+        handler: @escaping WebSocketDataHandler<Context>,
+        context: Context
+    ) async {
+        let webSocketOutbound = WebSocketOutboundWriter(handler: self)
+        var inboundIterator = inbound.makeAsyncIterator()
+        let webSocketInbound = WebSocketInboundStream(
+            inboundIterator: inboundIterator,
+            handler: self
+        )
+        try? await withGracefulShutdownHandler {
+            let closeCode: WebSocketErrorCode
+            do {
+                // handle websocket data and text
+                try await handler(webSocketInbound, webSocketOutbound, context)
+                closeCode = .normalClosure
+            } catch InternalError.close(let code) {
+                closeCode = code
+            } catch {
+                closeCode = .unexpectedServerError
+            }
+            try await self.close(code: closeCode)
+            // Close handshake. Wait for responding close or until inbound ends
+            while let packet = try await inboundIterator.next() {
+                if case .connectionClose = packet.opcode {
+                    // we received a connection close.
+                    // send a close back if it hasn't already been send and exit
+                    _ = try await self.close(code: .normalClosure)
+                    break
+                }
+            }
+        } onGracefulShutdown: {
+            Task {
+                try? await self.close(code: .normalClosure)
+            }
+        }
+    }
+
+    /// Send WebSocket frame
+    func write(frame: WebSocketFrame) async throws {
+        var frame = frame
+        do {
+            for ext in self.extensions {
+                frame = try await ext.processFrameToSend(frame, context: self.context)
+            }
+        } catch {
+            self.context.logger.debug("Closing as we failed to generate valid frame data")
+            throw WebSocketHandler.InternalError.close(.unexpectedServerError)
+        }
+        frame.maskKey = self.makeMaskKey()
+        try await self.outbound.write(frame)
+
+        self.context.logger.trace("Sent \(frame.opcode)")
+    }
+
+    func finish() {
+        self.outbound.finish()
+    }
+
     /// Respond to ping
     func onPing(
-        _ frame: WebSocketFrame,
-        outbound: WebSocketOutboundWriter<some WebSocketContextProtocol>,
-        context: some WebSocketContextProtocol
+        _ frame: WebSocketFrame
     ) async throws {
         if frame.fin {
-            try await self.pong(data: frame.unmaskedData, outbound: outbound)
+            try await self.pong(data: frame.unmaskedData)
         } else {
-            try await self.close(code: .protocolError, outbound: outbound, context: context)
+            try await self.close(code: .protocolError)
         }
     }
 
     /// Respond to pong
     func onPong(
-        _ frame: WebSocketFrame,
-        outbound: WebSocketOutboundWriter<some WebSocketContextProtocol>,
-        context: some WebSocketContextProtocol
+        _ frame: WebSocketFrame
     ) async throws {
         guard !self.closed else { return }
         let frameData = frame.unmaskedData
         guard self.pingData.readableBytes == 0 || frameData == self.pingData else {
-            try await self.close(code: .goingAway, outbound: outbound, context: context)
+            try await self.close(code: .goingAway)
             return
         }
         self.pingData.clear()
     }
 
     /// Send ping
-    func ping(outbound: WebSocketOutboundWriter<some WebSocketContextProtocol>) async throws {
+    func ping() async throws {
         guard !self.closed else { return }
         if self.pingData.readableBytes == 0 {
             // creating random payload
             let random = (0..<Self.pingDataSize).map { _ in UInt8.random(in: 0...255) }
             self.pingData.writeBytes(random)
         }
-        try await outbound.write(frame: .init(fin: true, opcode: .ping, data: self.pingData))
+        try await self.outbound.write(.init(fin: true, opcode: .ping, data: self.pingData))
     }
 
     /// Send pong
-    func pong(data: ByteBuffer?, outbound: WebSocketOutboundWriter<some WebSocketContextProtocol>) async throws {
+    func pong(data: ByteBuffer?) async throws {
         guard !self.closed else { return }
-        try await outbound.write(frame: .init(fin: true, opcode: .pong, data: data ?? .init()))
+        try await self.outbound.write(.init(fin: true, opcode: .pong, data: data ?? .init()))
     }
 
     /// Send close
     func close(
-        code: WebSocketErrorCode = .normalClosure,
-        outbound: WebSocketOutboundWriter<some WebSocketContextProtocol>,
-        context: some WebSocketContextProtocol
+        code: WebSocketErrorCode = .normalClosure
     ) async throws {
         guard !self.closed else { return }
         self.closed = true
 
-        var buffer = context.allocator.buffer(capacity: 2)
+        var buffer = self.context.allocator.buffer(capacity: 2)
         buffer.write(webSocketErrorCode: code)
-        try await outbound.write(frame: .init(fin: true, opcode: .connectionClose, data: buffer))
+        try await self.outbound.write(.init(fin: true, opcode: .connectionClose, data: buffer))
         // Only server should initiate a connection close. Clients should wait for the
         // server to close the connection when it receives the WebSocket close packet
         // See https://www.rfc-editor.org/rfc/rfc6455#section-7.1.1
         if self.type == .server {
-            outbound.finish()
+            self.outbound.finish()
+        }
+    }
+
+    /// Make mask key to be used in WebSocket frame
+    private func makeMaskKey() -> WebSocketMaskingKey? {
+        guard self.type == .client else { return nil }
+        let bytes: [UInt8] = (0...3).map { _ in UInt8.random(in: .min ... .max) }
+        return WebSocketMaskingKey(bytes)
+    }
+
+    actor WebSocketInternal {
+        static let pingDataSize = 16
+        var outbound: NIOAsyncChannelOutboundWriter<WebSocketFrame>
+        let type: WebSocketType
+        let extensions: [any WebSocketExtension]
+        let context: WebSocketContext
+        var pingData: ByteBuffer
+        var closed = false
+
+        init(
+            outbound: NIOAsyncChannelOutboundWriter<WebSocketFrame>,
+            type: WebSocketType,
+            extensions: [any WebSocketExtension],
+            context: some WebSocketContextProtocol
+        ) {
+            self.outbound = outbound
+            self.type = type
+            self.extensions = extensions
+            self.context = .init(allocator: context.allocator, logger: context.logger)
+            self.pingData = ByteBufferAllocator().buffer(capacity: Self.pingDataSize)
+            self.closed = false
+        }
+
+        /// Send WebSocket frame
+        func write(frame: WebSocketFrame) async throws {
+            var frame = frame
+            do {
+                for ext in self.extensions {
+                    frame = try await ext.processFrameToSend(frame, context: self.context)
+                }
+            } catch {
+                self.context.logger.debug("Closing as we failed to generate valid frame data")
+                throw WebSocketHandler.InternalError.close(.unexpectedServerError)
+            }
+            frame.maskKey = self.makeMaskKey()
+            try await self.outbound.write(frame)
+
+            self.context.logger.trace("Sent \(frame.opcode)")
+        }
+
+        func finish() {
+            self.outbound.finish()
+        }
+
+        /// Respond to ping
+        func onPing(
+            _ frame: WebSocketFrame
+        ) async throws {
+            if frame.fin {
+                try await self.pong(data: frame.unmaskedData)
+            } else {
+                try await self.close(code: .protocolError)
+            }
+        }
+
+        /// Respond to pong
+        func onPong(
+            _ frame: WebSocketFrame
+        ) async throws {
+            guard !self.closed else { return }
+            let frameData = frame.unmaskedData
+            guard self.pingData.readableBytes == 0 || frameData == self.pingData else {
+                try await self.close(code: .goingAway)
+                return
+            }
+            self.pingData.clear()
+        }
+
+        /// Send ping
+        func ping() async throws {
+            guard !self.closed else { return }
+            if self.pingData.readableBytes == 0 {
+                // creating random payload
+                let random = (0..<Self.pingDataSize).map { _ in UInt8.random(in: 0...255) }
+                self.pingData.writeBytes(random)
+            }
+            try await self.outbound.write(.init(fin: true, opcode: .ping, data: self.pingData))
+        }
+
+        /// Send pong
+        func pong(data: ByteBuffer?) async throws {
+            guard !self.closed else { return }
+            try await self.outbound.write(.init(fin: true, opcode: .pong, data: data ?? .init()))
+        }
+
+        /// Send close
+        func close(
+            code: WebSocketErrorCode = .normalClosure
+        ) async throws {
+            guard !self.closed else { return }
+            self.closed = true
+
+            var buffer = self.context.allocator.buffer(capacity: 2)
+            buffer.write(webSocketErrorCode: code)
+            try await self.outbound.write(.init(fin: true, opcode: .connectionClose, data: buffer))
+            self.outbound.finish()
+        }
+
+        /// Make mask key to be used in WebSocket frame
+        private func makeMaskKey() -> WebSocketMaskingKey? {
+            guard self.type == .client else { return nil }
+            let bytes: [UInt8] = (0...3).map { _ in UInt8.random(in: .min ... .max) }
+            return WebSocketMaskingKey(bytes)
         }
     }
 }

--- a/Sources/HummingbirdWebSocket/WebSocketInboundStream.swift
+++ b/Sources/HummingbirdWebSocket/WebSocketInboundStream.swift
@@ -13,52 +13,95 @@
 //===----------------------------------------------------------------------===//
 
 import AsyncAlgorithms
+import NIOConcurrencyHelpers
 import NIOCore
 import NIOWebSocket
 
+private let webSocketPingDataSize = 16
+
 /// Inbound websocket data AsyncSequence
-public typealias WebSocketInboundStream = AsyncChannel<WebSocketDataFrame>
+// public typealias WebSocketInboundStream = AsyncChannel<WebSocketDataFrame>
 
-/// Enumeration holding WebSocket data
-public enum WebSocketDataFrame: Equatable, Sendable, CustomStringConvertible, CustomDebugStringConvertible {
-    case text(String)
-    case binary(ByteBuffer)
+public final class WebSocketInboundStream: AsyncSequence, Sendable {
+    typealias InboundIterator = NIOAsyncChannelInboundStream<WebSocketFrame>.AsyncIterator
+    let inboundIterator: UnsafeTransfer<InboundIterator>
+    let handler: WebSocketHandler
 
-    init?(frame: WebSocketFrame) {
-        switch frame.opcode {
-        case .text:
-            self = .text(String(buffer: frame.unmaskedData))
-        case .binary:
-            self = .binary(frame.unmaskedData)
-        default:
+    init(
+        inboundIterator: InboundIterator,
+        handler: WebSocketHandler
+    ) {
+        self.inboundIterator = .init(inboundIterator)
+        self.handler = handler
+    }
+
+    public struct AsyncIterator: AsyncIteratorProtocol {
+        let handler: WebSocketHandler
+        var iterator: InboundIterator
+
+        init(sequence: WebSocketInboundStream) {
+            self.handler = sequence.handler
+            self.iterator = sequence.inboundIterator.wrappedValue
+        }
+
+        public mutating func next() async throws -> WebSocketDataFrame? {
+            // parse messages coming from inbound
+            var frameSequence: WebSocketFrameSequence?
+            while let frame = try await self.iterator.next() {
+                do {
+                    self.handler.context.logger.trace("Received \(frame.opcode)")
+                    switch frame.opcode {
+                    case .connectionClose:
+                        // we received a connection close.
+                        // send a close back if it hasn't already been send and exit
+                        _ = try await self.handler.close(code: .normalClosure)
+                        return nil
+                    case .ping:
+                        try await self.handler.onPing(frame)
+                    case .pong:
+                        try await self.handler.onPong(frame)
+                    case .text, .binary:
+                        if var frameSeq = frameSequence {
+                            frameSeq.append(frame)
+                            frameSequence = frameSeq
+                        } else {
+                            frameSequence = WebSocketFrameSequence(frame: frame)
+                        }
+                    case .continuation:
+                        if var frameSeq = frameSequence {
+                            frameSeq.append(frame)
+                            frameSequence = frameSeq
+                        } else {
+                            try await self.handler.close(code: .protocolError)
+                        }
+                    default:
+                        break
+                    }
+                    if let frameSeq = frameSequence, frame.fin {
+                        var collatedFrame = frameSeq.collapsed
+                        for ext in self.handler.extensions.reversed() {
+                            collatedFrame = try await ext.processReceivedFrame(collatedFrame, context: self.handler.context)
+                        }
+                        if let finalFrame = WebSocketDataFrame(frame: collatedFrame) {
+                            frameSequence = nil
+                            return finalFrame
+                        }
+                    }
+                } catch {
+                    // catch errors while processing websocket frames so responding close message
+                    // can be dealt with
+                    let errorCode = WebSocketErrorCode(error)
+                    try await self.handler.close(code: errorCode)
+                }
+            }
+
             return nil
         }
     }
 
-    public var webSocketFrame: WebSocketFrame {
-        switch self {
-        case .text(let string):
-            return .init(fin: true, opcode: .text, data: ByteBuffer(string: string))
-        case .binary(let buffer):
-            return .init(fin: true, opcode: .binary, data: buffer)
-        }
-    }
+    public typealias Element = WebSocketDataFrame
 
-    public var description: String {
-        switch self {
-        case .text(let string):
-            return "string(\"\(string)\")"
-        case .binary(let buffer):
-            return "binary(\(buffer.description))"
-        }
-    }
-
-    public var debugDescription: String {
-        switch self {
-        case .text(let string):
-            return "string(\"\(string)\")"
-        case .binary(let buffer):
-            return "binary(\(buffer.debugDescription))"
-        }
+    public func makeAsyncIterator() -> AsyncIterator {
+        .init(sequence: self)
     }
 }

--- a/Tests/HummingbirdWebSocketTests/WebSocketTests.swift
+++ b/Tests/HummingbirdWebSocketTests/WebSocketTests.swift
@@ -223,7 +223,7 @@ final class HummingbirdWebSocketTests: XCTestCase {
             try await outbound.write(.text("Hello"))
         } client: { inbound, _, _ in
             var inboundIterator = inbound.makeAsyncIterator()
-            let msg = await inboundIterator.next()
+            let msg = try await inboundIterator.next()
             XCTAssertEqual(msg, .text("Hello"))
         }
     }
@@ -231,7 +231,7 @@ final class HummingbirdWebSocketTests: XCTestCase {
     func testClientToServerMessage() async throws {
         try await self.testClientAndServer { inbound, _, _ in
             var inboundIterator = inbound.makeAsyncIterator()
-            let msg = await inboundIterator.next()
+            let msg = try await inboundIterator.next()
             XCTAssertEqual(msg, .text("Hello"))
         } client: { _, outbound, _ in
             try await outbound.write(.text("Hello"))
@@ -250,7 +250,7 @@ final class HummingbirdWebSocketTests: XCTestCase {
             try await outbound.write(.custom(.init(fin: true, opcode: .text, data: buffer2)))
 
             var inboundIterator = inbound.makeAsyncIterator()
-            let msg = await inboundIterator.next()
+            let msg = try await inboundIterator.next()
             XCTAssertEqual(msg, .text("Hello World!"))
         }
     }
@@ -302,7 +302,7 @@ final class HummingbirdWebSocketTests: XCTestCase {
                 logger: logger
             ) { inbound, _, _ in
                 var inboundIterator = inbound.makeAsyncIterator()
-                let msg = await inboundIterator.next()
+                let msg = try await inboundIterator.next()
                 XCTAssertEqual(msg, .text("Hello"))
             }
         }
@@ -390,7 +390,7 @@ final class HummingbirdWebSocketTests: XCTestCase {
             group.addTask {
                 try await WebSocketClient.connect(url: .init("ws://localhost:\(promise.wait())/ws"), logger: logger) { inbound, _, _ in
                     var inboundIterator = inbound.makeAsyncIterator()
-                    let msg = await inboundIterator.next()
+                    let msg = try await inboundIterator.next()
                     XCTAssertEqual(msg, .text("Hello"))
                 }
             }
@@ -414,14 +414,14 @@ final class HummingbirdWebSocketTests: XCTestCase {
         try await self.testClientAndServerWithRouter(webSocketRouter: router, uri: "localhost:8080") { port, logger in
             try WebSocketClient(url: .init("ws://localhost:\(port)/ws1"), logger: logger) { inbound, _, _ in
                 var inboundIterator = inbound.makeAsyncIterator()
-                let msg = await inboundIterator.next()
+                let msg = try await inboundIterator.next()
                 XCTAssertEqual(msg, .text("One"))
             }
         }
         try await self.testClientAndServerWithRouter(webSocketRouter: router, uri: "localhost:8080") { port, logger in
             try WebSocketClient(url: .init("ws://localhost:\(port)/ws2"), logger: logger) { inbound, _, _ in
                 var inboundIterator = inbound.makeAsyncIterator()
-                let msg = await inboundIterator.next()
+                let msg = try await inboundIterator.next()
                 XCTAssertEqual(msg, .text("Two"))
             }
         }
@@ -487,7 +487,7 @@ final class HummingbirdWebSocketTests: XCTestCase {
         do {
             try await self.testClientAndServerWithRouter(webSocketRouter: router, uri: "localhost:8080") { port, logger in
                 try WebSocketClient(url: .init("ws://localhost:\(port)/ws"), logger: logger) { inbound, _, _ in
-                    let text = await inbound.first { _ in true }
+                    let text = try await inbound.first { _ in true }
                     XCTAssertEqual(text, .text("Roger Moore"))
                 }
             }


### PR DESCRIPTION
Instead of creating a new AsyncChannel to push data frames to, wrap the inbound WebSocketFrame iterator in an AsyncSequence and pass that to the handler. 
