### PR TITLE
Add min frame to compress config/fix closing bug

### DIFF
--- a/Snippets/AutobahnClientTest.swift
+++ b/Snippets/AutobahnClientTest.swift
@@ -2,7 +2,20 @@ import HummingbirdWSClient
 import HummingbirdWSCompression
 import Logging
 
-let cases = 1...1
+// Autobahn tests
+// 1. Framing
+// 2. Pings/Pongs
+// 3. Reserved bits
+// 4. Opcodes
+// 5. Fragmentation
+// 6. UTF8 handling
+// 7. Close handling
+// 9. Limits/performance
+// 10. Misc
+// 12. WebSocket compression (different payloads)
+// 13. WebSocket compression (different parameters)
+
+let cases = 1...102
 
 var logger = Logger(label: "TestClient")
 logger.logLevel = .trace

--- a/Sources/HummingbirdWSClient/Client/ClientChannel.swift
+++ b/Sources/HummingbirdWSClient/Client/ClientChannel.swift
@@ -16,6 +16,7 @@ import Logging
 import NIOCore
 
 /// ClientConnection child channel setup protocol
+@_documentation(visibility: internal)
 public protocol ClientConnectionChannel: Sendable {
     associatedtype Value: Sendable
 

--- a/Sources/HummingbirdWSClient/Client/ClientConnection.swift
+++ b/Sources/HummingbirdWSClient/Client/ClientConnection.swift
@@ -23,6 +23,7 @@ import NIOTransportServices
 /// A generic client connection to a server.
 ///
 /// Actual client protocol is implemented in `ClientChannel` generic parameter
+@_documentation(visibility: internal)
 public struct ClientConnection<ClientChannel: ClientConnectionChannel>: Sendable {
     /// Address to connect to
     public struct Address: Sendable, Equatable {

--- a/Sources/HummingbirdWSClient/Client/TLSClientChannel.swift
+++ b/Sources/HummingbirdWSClient/Client/TLSClientChannel.swift
@@ -17,6 +17,7 @@ import NIOCore
 import NIOSSL
 
 /// Sets up client channel to use TLS before accessing base channel setup
+@_documentation(visibility: internal)
 public struct TLSClientChannel<BaseChannel: ClientConnectionChannel>: ClientConnectionChannel {
     public typealias Value = BaseChannel.Value
 

--- a/Sources/HummingbirdWSCompression/PerMessageDeflateExtension.swift
+++ b/Sources/HummingbirdWSCompression/PerMessageDeflateExtension.swift
@@ -232,9 +232,9 @@ struct PerMessageDeflateExtension: WebSocketExtension {
         }
 
         func compress(_ frame: WebSocketFrame, resetStream: Bool, context: some WebSocketContext) throws -> WebSocketFrame {
-            // if the frame is larger than `minFrameSizeToCompress` bytes, we haven't received a final frame 
+            // if the frame is larger than `minFrameSizeToCompress` bytes, we haven't received a final frame
             // or we are in the process of sending a message compress the data
-            let shouldWeCompress = frame.data.readableBytes >= minFrameSizeToCompress || !frame.fin || self.sendState != .idle
+            let shouldWeCompress = frame.data.readableBytes >= self.minFrameSizeToCompress || !frame.fin || self.sendState != .idle
             if shouldWeCompress {
                 var newFrame = frame
                 if self.sendState == .idle {

--- a/Sources/HummingbirdWSCore/WebSocketHandler.swift
+++ b/Sources/HummingbirdWSCore/WebSocketHandler.swift
@@ -151,14 +151,16 @@ package actor WebSocketHandler {
             } catch {
                 closeCode = .unexpectedServerError
             }
-            try await self.close(code: closeCode)
-            // Close handshake. Wait for responding close or until inbound ends
-            while let packet = try await inboundIterator.next() {
-                if case .connectionClose = packet.opcode {
-                    // we received a connection close.
-                    // send a close back if it hasn't already been send and exit
-                    _ = try await self.close(code: .normalClosure)
-                    break
+            if !self.closed {
+                try await self.close(code: closeCode)
+                // Close handshake. Wait for responding close or until inbound ends
+                while let packet = try await inboundIterator.next() {
+                    if case .connectionClose = packet.opcode {
+                        // we received a connection close.
+                        // send a close back if it hasn't already been send and exit
+                        _ = try await self.close(code: .normalClosure)
+                        break
+                    }
                 }
             }
         } onGracefulShutdown: {

--- a/Sources/HummingbirdWSCore/WebSocketInboundStream.swift
+++ b/Sources/HummingbirdWSCore/WebSocketInboundStream.swift
@@ -60,20 +60,7 @@ public final class WebSocketInboundStream: AsyncSequence, Sendable {
                     self.handler.context.logger.trace("Received \(frame.traceDescription)")
                     switch frame.opcode {
                     case .connectionClose:
-                        // we received a connection close.
-                        // send a close back if it hasn't already been send and exit
-                        var data = frame.unmaskedData
-                        let dataSize = data.readableBytes
-                        let closeCode = data.readWebSocketErrorCode()
-                        if dataSize == 0 || closeCode != nil {
-                            if case .unknown = closeCode {
-                                _ = try await self.handler.close(code: .protocolError)
-                            } else {
-                                _ = try await self.handler.close(code: .normalClosure)
-                            }
-                        } else {
-                            _ = try await self.handler.close(code: .protocolError)
-                        }
+                        try await self.handler.receivedClose(frame)
                         return nil
                     case .ping:
                         try await self.handler.onPing(frame)

--- a/Tests/HummingbirdWebSocketTests/WebSocketExtensionTests.swift
+++ b/Tests/HummingbirdWebSocketTests/WebSocketExtensionTests.swift
@@ -288,7 +288,7 @@ final class HummingbirdWebSocketExtensionTests: XCTestCase {
         try await self.testClientAndServer(
             serverExtensions: [.checkDeflate(), .perMessageDeflate(minFrameSizeToCompress: 16)],
             clientExtensions: [.checkDeflate(), .perMessageDeflate(minFrameSizeToCompress: 16)]
-        ) { inbound, _, context in
+        ) { inbound, _, _ in
             var iterator = inbound.messages(maxSize: .max).makeAsyncIterator()
             let firstMessage = try await iterator.next()
             // The first message should be received
@@ -297,7 +297,7 @@ final class HummingbirdWebSocketExtensionTests: XCTestCase {
             // an error because it hasn't been compressed
             let nextMessage = try await iterator.next()
             XCTAssertEqual(nextMessage, nil)
-        } client: { inbound, outbound, context in
+        } client: { inbound, outbound, _ in
             try await outbound.write(.text("Hello, testing this is compressed"))
             try await outbound.write(.text("Hello"))
             for try await _ in inbound {}

--- a/scripts/autobahn-config/fuzzingserver.json
+++ b/scripts/autobahn-config/fuzzingserver.json
@@ -3,6 +3,7 @@
     "outdir": "./reports/clients",
     "cases": ["*"],
     "exclude-cases": [
+        "6.*",
         "9.*",
         "12.*",
         "13.*"


### PR DESCRIPTION
These two are combined as the test for the min frame to compress revealed the close issue
- Added new config value which defines the minimum size of frame before running compression, previously this was fixed to 16 bytes which is quite low.
- Fix close issue where a handler receives a close frame so exits and then sends the responding the close frame. Previously it would then wait for a response. Fixed this by changing the closed boolean into an enum that details the close state, this catches if we have received a close frame already