### PR TITLE
Return close code from WebSocketClient.run/connect

### DIFF
--- a/Sources/HummingbirdWSClient/Client/ClientChannel.swift
+++ b/Sources/HummingbirdWSClient/Client/ClientChannel.swift
@@ -19,6 +19,7 @@ import NIOCore
 @_documentation(visibility: internal)
 public protocol ClientConnectionChannel: Sendable {
     associatedtype Value: Sendable
+    associatedtype Result
 
     /// Setup child channel
     /// - Parameters:
@@ -31,5 +32,5 @@ public protocol ClientConnectionChannel: Sendable {
     /// - Parameters:
     ///   - value: Object to process input/output on child channel
     ///   - logger: Logger to use while processing messages
-    func handle(value: Value, logger: Logger) async throws
+    func handle(value: Value, logger: Logger) async throws -> Result
 }

--- a/Sources/HummingbirdWSClient/Client/ClientConnection.swift
+++ b/Sources/HummingbirdWSClient/Client/ClientConnection.swift
@@ -19,6 +19,7 @@ import NIOPosix
 import Network
 import NIOTransportServices
 #endif
+import NIOWebSocket
 
 /// A generic client connection to a server.
 ///
@@ -86,12 +87,12 @@ public struct ClientConnection<ClientChannel: ClientConnectionChannel>: Sendable
     }
     #endif
 
-    public func run() async throws {
+    public func run() async throws -> ClientChannel.Result {
         let channelResult = try await self.makeClient(
             clientChannel: self.clientChannel,
             address: self.address
         )
-        try await self.clientChannel.handle(value: channelResult, logger: self.logger)
+        return try await self.clientChannel.handle(value: channelResult, logger: self.logger)
     }
 
     /// Connect to server

--- a/Sources/HummingbirdWSClient/Client/TLSClientChannel.swift
+++ b/Sources/HummingbirdWSClient/Client/TLSClientChannel.swift
@@ -15,11 +15,13 @@
 import Logging
 import NIOCore
 import NIOSSL
+import NIOWebSocket
 
 /// Sets up client channel to use TLS before accessing base channel setup
 @_documentation(visibility: internal)
 public struct TLSClientChannel<BaseChannel: ClientConnectionChannel>: ClientConnectionChannel {
     public typealias Value = BaseChannel.Value
+    public typealias Result = BaseChannel.Result
 
     ///  Initialize TLSChannel
     /// - Parameters:
@@ -51,7 +53,7 @@ public struct TLSClientChannel<BaseChannel: ClientConnectionChannel>: ClientConn
     /// - Parameters:
     ///   - value: Object to process input/output on child channel
     ///   - logger: Logger to use while processing messages
-    public func handle(value: BaseChannel.Value, logger: Logging.Logger) async throws {
+    public func handle(value: BaseChannel.Value, logger: Logging.Logger) async throws -> Result {
         try await self.baseChannel.handle(value: value, logger: logger)
     }
 

--- a/Sources/HummingbirdWSClient/WebSocketClient.swift
+++ b/Sources/HummingbirdWSClient/WebSocketClient.swift
@@ -113,8 +113,8 @@ public struct WebSocketClient {
     #endif
 
     /// Connect and run handler
-    /// - Returns: WebSocket close code if server returned one
-    @discardableResult public func run() async throws -> WebSocketErrorCode? {
+    /// - Returns: WebSocket close frame details if server returned any
+    @discardableResult public func run() async throws -> WebSocketCloseFrame? {
         guard let host = url.host else { throw WebSocketClientError.invalidURL }
         let requiresTLS = self.url.scheme == .wss || self.url.scheme == .https
         let port = self.url.port ?? (requiresTLS ? 443 : 80)
@@ -188,7 +188,7 @@ extension WebSocketClient {
     ///   - eventLoopGroup: EventLoopGroup to run WebSocket client on
     ///   - logger: Logger
     ///   - process: Closure handling webSocket
-    /// - Returns: WebSocket close code if server returned one
+    /// - Returns: WebSocket close frame details if server returned any
     @discardableResult public static func connect(
         url: String,
         configuration: WebSocketClientConfiguration = .init(),
@@ -196,7 +196,7 @@ extension WebSocketClient {
         eventLoopGroup: EventLoopGroup = MultiThreadedEventLoopGroup.singleton,
         logger: Logger,
         handler: @escaping WebSocketDataHandler<BasicWebSocketContext>
-    ) async throws -> WebSocketErrorCode? {
+    ) async throws -> WebSocketCloseFrame? {
         let ws = self.init(
             url: url,
             configuration: configuration,
@@ -218,7 +218,7 @@ extension WebSocketClient {
     ///   - eventLoopGroup: EventLoopGroup to run WebSocket client on
     ///   - logger: Logger
     ///   - process: WebSocket data handler
-    /// - Returns: WebSocket close code if server returned one
+    /// - Returns: WebSocket close frame details if server returned any
     public static func connect(
         url: String,
         configuration: WebSocketClientConfiguration = .init(),
@@ -226,7 +226,7 @@ extension WebSocketClient {
         eventLoopGroup: NIOTSEventLoopGroup = NIOTSEventLoopGroup.singleton,
         logger: Logger,
         handler: @escaping WebSocketDataHandler<BasicWebSocketContext>
-    ) async throws -> WebSocketErrorCode? {
+    ) async throws -> WebSocketCloseFrame? {
         let ws = self.init(
             url: url,
             configuration: configuration,

--- a/Sources/HummingbirdWSClient/WebSocketClient.swift
+++ b/Sources/HummingbirdWSClient/WebSocketClient.swift
@@ -112,7 +112,8 @@ public struct WebSocketClient {
     }
     #endif
 
-    ///  Connect and run handler
+    /// Connect and run handler
+    /// - Returns: WebSocket close code if server returned one
     @discardableResult public func run() async throws -> WebSocketErrorCode? {
         guard let host = url.host else { throw WebSocketClientError.invalidURL }
         let requiresTLS = self.url.scheme == .wss || self.url.scheme == .https
@@ -187,6 +188,7 @@ extension WebSocketClient {
     ///   - eventLoopGroup: EventLoopGroup to run WebSocket client on
     ///   - logger: Logger
     ///   - process: Closure handling webSocket
+    /// - Returns: WebSocket close code if server returned one
     @discardableResult public static func connect(
         url: String,
         configuration: WebSocketClientConfiguration = .init(),
@@ -216,6 +218,7 @@ extension WebSocketClient {
     ///   - eventLoopGroup: EventLoopGroup to run WebSocket client on
     ///   - logger: Logger
     ///   - process: WebSocket data handler
+    /// - Returns: WebSocket close code if server returned one
     public static func connect(
         url: String,
         configuration: WebSocketClientConfiguration = .init(),

--- a/Sources/HummingbirdWSClient/WebSocketClientChannel.swift
+++ b/Sources/HummingbirdWSClient/WebSocketClientChannel.swift
@@ -94,10 +94,10 @@ struct WebSocketClientChannel: ClientConnectionChannel {
         }
     }
 
-    func handle(value: Value, logger: Logger) async throws {
+    func handle(value: Value, logger: Logger) async throws -> WebSocketErrorCode? {
         switch try await value.get() {
         case .websocket(let webSocketChannel, let extensions):
-            await WebSocketHandler.handle(
+            return try await WebSocketHandler.handle(
                 type: .client,
                 configuration: .init(
                     extensions: extensions,

--- a/Sources/HummingbirdWSClient/WebSocketClientChannel.swift
+++ b/Sources/HummingbirdWSClient/WebSocketClientChannel.swift
@@ -94,7 +94,7 @@ struct WebSocketClientChannel: ClientConnectionChannel {
         }
     }
 
-    func handle(value: Value, logger: Logger) async throws -> WebSocketErrorCode? {
+    func handle(value: Value, logger: Logger) async throws -> WebSocketCloseFrame? {
         switch try await value.get() {
         case .websocket(let webSocketChannel, let extensions):
             return try await WebSocketHandler.handle(

--- a/Sources/HummingbirdWSCore/WebSocketOutboundWriter.swift
+++ b/Sources/HummingbirdWSCore/WebSocketOutboundWriter.swift
@@ -51,6 +51,21 @@ public struct WebSocketOutboundWriter: Sendable {
         }
     }
 
+    /// Send close control frame.
+    ///
+    /// In most cases calling this is unnecessary as the WebSocket handling code will do
+    /// this for you automatically, but if you want to send a custom close code or reason
+    /// use this function.
+    ///
+    /// After calling this function you should not send anymore data
+    /// - Parameters:
+    ///   - closeCode: Close code
+    ///   - reason: Close reason string
+    public func close(_ closeCode: WebSocketErrorCode, reason: String?) async throws {
+        try await self.handler.close(code: closeCode, reason: reason)
+    }
+
+    /// Write WebSocket message as a series as frames
     public struct MessageWriter {
         let opcode: WebSocketOpcode
         let handler: WebSocketHandler

--- a/Sources/HummingbirdWebSocket/WebSocketChannel.swift
+++ b/Sources/HummingbirdWebSocket/WebSocketChannel.swift
@@ -63,16 +63,20 @@ public struct HTTP1WebSocketUpgradeChannel: ServerChildChannel, HTTPChannelHandl
                         )
                         return (headers, { asyncChannel, logger in
                             let context = BasicWebSocketContext(allocator: channel.allocator, logger: logger)
-                            await WebSocketHandler.handle(
-                                type: .server,
-                                configuration: .init(
-                                    extensions: extensions,
-                                    autoPing: configuration.autoPing
-                                ),
-                                asyncChannel: asyncChannel,
-                                context: context,
-                                handler: handler
-                            )
+                            do {
+                                _ = try await WebSocketHandler.handle(
+                                    type: .server,
+                                    configuration: .init(
+                                        extensions: extensions,
+                                        autoPing: configuration.autoPing
+                                    ),
+                                    asyncChannel: asyncChannel,
+                                    context: context,
+                                    handler: handler
+                                )
+                            } catch {
+                                logger.debug("WebSocket handler error", metadata: ["error": "\(error)"])
+                            }
                         })
                     }
             }
@@ -108,16 +112,20 @@ public struct HTTP1WebSocketUpgradeChannel: ServerChildChannel, HTTPChannelHandl
                         )
                         return (headers, { asyncChannel, logger in
                             let context = BasicWebSocketContext(allocator: channel.allocator, logger: logger)
-                            await WebSocketHandler.handle(
-                                type: .server,
-                                configuration: .init(
-                                    extensions: extensions,
-                                    autoPing: configuration.autoPing
-                                ),
-                                asyncChannel: asyncChannel,
-                                context: context,
-                                handler: handler
-                            )
+                            do {
+                                _ = try await WebSocketHandler.handle(
+                                    type: .server,
+                                    configuration: .init(
+                                        extensions: extensions,
+                                        autoPing: configuration.autoPing
+                                    ),
+                                    asyncChannel: asyncChannel,
+                                    context: context,
+                                    handler: handler
+                                )
+                            } catch {
+                                logger.debug("WebSocket handler error", metadata: ["error": "\(error)"])
+                            }
                         })
                     }
             }

--- a/Sources/HummingbirdWebSocket/WebSocketRouter.swift
+++ b/Sources/HummingbirdWebSocket/WebSocketRouter.swift
@@ -169,16 +169,20 @@ extension HTTP1WebSocketUpgradeChannel {
                             logger: logger
                         )
                         return .upgrade(headers) { asyncChannel, _ in
-                            await WebSocketHandler.handle(
-                                type: .server,
-                                configuration: .init(
-                                    extensions: extensions,
-                                    autoPing: configuration.autoPing
-                                ),
-                                asyncChannel: asyncChannel,
-                                context: WebSocketContextFromRouter(request: request, context: webSocketHandler.context),
-                                handler: webSocketHandler.handler
-                            )
+                            do {
+                                _ = try await WebSocketHandler.handle(
+                                    type: .server,
+                                    configuration: .init(
+                                        extensions: extensions,
+                                        autoPing: configuration.autoPing
+                                    ),
+                                    asyncChannel: asyncChannel,
+                                    context: WebSocketContextFromRouter(request: request, context: webSocketHandler.context),
+                                    handler: webSocketHandler.handler
+                                )
+                            } catch {
+                                logger.debug("WebSocket handler error", metadata: ["error": "\(error)"])
+                            }
                         }
                     } else {
                         return .dontUpgrade

--- a/Tests/HummingbirdWebSocketTests/WebSocketTests.swift
+++ b/Tests/HummingbirdWebSocketTests/WebSocketTests.swift
@@ -565,6 +565,16 @@ final class HummingbirdWebSocketTests: XCTestCase {
         XCTAssertEqual(rt?.closeCode, .normalClosure)
     }
 
+    func testCloseReason() async throws {
+        let rt = try await self.testClientAndServer { _, outbound, _ in
+            try await outbound.close(.unknown(3000), reason: "Because")
+        } client: { inbound, _, _ in
+            for try await _ in inbound {}
+        }
+        XCTAssertEqual(rt?.closeCode, .unknown(3000))
+        XCTAssertEqual(rt?.reason, "Because")
+    }
+
     func testCloseMessageTooLargeError() async throws {
         let rt = try await self.testClientAndServer { inbound, _, _ in
             for try await _ in inbound {}

--- a/Tests/HummingbirdWebSocketTests/WebSocketTests.swift
+++ b/Tests/HummingbirdWebSocketTests/WebSocketTests.swift
@@ -562,7 +562,6 @@ final class HummingbirdWebSocketTests: XCTestCase {
             for try await _ in inbound {}
         } client: { _, _, _ in
         }
-        // Send a message that was too large so expect a too large error message back
         XCTAssertEqual(rt, .normalClosure)
     }
 


### PR DESCRIPTION
- Return close code from WebSocketHandler. This is ignored by the server but passed back to the user when using the client
- Also throw errors, caused by closing WebSocket channel, Server should report these but otherwise ignore them. Client throws them