### PR TITLE
Add specific contexts for websocket types, delete BasicWebSocketContext

### DIFF
--- a/Sources/HummingbirdWSClient/Client/ClientConnection.swift
+++ b/Sources/HummingbirdWSClient/Client/ClientConnection.swift
@@ -145,7 +145,8 @@ public struct ClientConnection<ClientChannel: ClientConnectionChannel>: Sendable
     /// create a NIOTransportServices bootstrap using Network.framework
     private func createTSBootstrap() -> NIOTSConnectionBootstrap? {
         guard let bootstrap = NIOTSConnectionBootstrap(validatingGroup: self.eventLoopGroup)
-            .channelOption(ChannelOptions.allowRemoteHalfClosure, value: true) else {
+            .channelOption(ChannelOptions.allowRemoteHalfClosure, value: true)
+        else {
             return nil
         }
         if let tlsOptions {

--- a/Sources/HummingbirdWSClient/Client/ClientConnection.swift
+++ b/Sources/HummingbirdWSClient/Client/ClientConnection.swift
@@ -138,12 +138,14 @@ public struct ClientConnection<ClientChannel: ClientConnectionChannel>: Sendable
     /// create a BSD sockets based bootstrap
     private func createSocketsBootstrap() -> ClientBootstrap {
         return ClientBootstrap(group: self.eventLoopGroup)
+            .channelOption(ChannelOptions.allowRemoteHalfClosure, value: true)
     }
 
     #if canImport(Network)
     /// create a NIOTransportServices bootstrap using Network.framework
     private func createTSBootstrap() -> NIOTSConnectionBootstrap? {
-        guard let bootstrap = NIOTSConnectionBootstrap(validatingGroup: self.eventLoopGroup) else {
+        guard let bootstrap = NIOTSConnectionBootstrap(validatingGroup: self.eventLoopGroup)
+            .channelOption(ChannelOptions.allowRemoteHalfClosure, value: true) else {
             return nil
         }
         if let tlsOptions {

--- a/Sources/HummingbirdWSClient/WebSocketClient.swift
+++ b/Sources/HummingbirdWSClient/WebSocketClient.swift
@@ -40,6 +40,18 @@ import NIOWebSocket
 /// }
 /// ```
 public struct WebSocketClient {
+    /// Basic context implementation of ``WebSocketContext``.
+    /// Used by non-router web socket handle function
+    public struct Context: WebSocketContext {
+        public let allocator: ByteBufferAllocator
+        public let logger: Logger
+
+        package init(allocator: ByteBufferAllocator, logger: Logger) {
+            self.allocator = allocator
+            self.logger = logger
+        }
+    }
+
     enum MultiPlatformTLSConfiguration: Sendable {
         case niossl(TLSConfiguration)
         #if canImport(Network)
@@ -50,7 +62,7 @@ public struct WebSocketClient {
     /// WebSocket URL
     let url: URI
     /// WebSocket data handler
-    let handler: WebSocketDataHandler<BasicWebSocketContext>
+    let handler: WebSocketDataHandler<Context>
     /// configuration
     let configuration: WebSocketClientConfiguration
     /// EventLoopGroup to use
@@ -75,7 +87,7 @@ public struct WebSocketClient {
         tlsConfiguration: TLSConfiguration? = nil,
         eventLoopGroup: EventLoopGroup = MultiThreadedEventLoopGroup.singleton,
         logger: Logger,
-        handler: @escaping WebSocketDataHandler<BasicWebSocketContext>
+        handler: @escaping WebSocketDataHandler<Context>
     ) {
         self.url = .init(url)
         self.handler = handler
@@ -101,7 +113,7 @@ public struct WebSocketClient {
         transportServicesTLSOptions: TSTLSOptions,
         eventLoopGroup: NIOTSEventLoopGroup = NIOTSEventLoopGroup.singleton,
         logger: Logger,
-        handler: @escaping WebSocketDataHandler<BasicWebSocketContext>
+        handler: @escaping WebSocketDataHandler<Context>
     ) {
         self.url = .init(url)
         self.handler = handler
@@ -195,7 +207,7 @@ extension WebSocketClient {
         tlsConfiguration: TLSConfiguration? = nil,
         eventLoopGroup: EventLoopGroup = MultiThreadedEventLoopGroup.singleton,
         logger: Logger,
-        handler: @escaping WebSocketDataHandler<BasicWebSocketContext>
+        handler: @escaping WebSocketDataHandler<Context>
     ) async throws -> WebSocketCloseFrame? {
         let ws = self.init(
             url: url,
@@ -225,7 +237,7 @@ extension WebSocketClient {
         transportServicesTLSOptions: TSTLSOptions,
         eventLoopGroup: NIOTSEventLoopGroup = NIOTSEventLoopGroup.singleton,
         logger: Logger,
-        handler: @escaping WebSocketDataHandler<BasicWebSocketContext>
+        handler: @escaping WebSocketDataHandler<Context>
     ) async throws -> WebSocketCloseFrame? {
         let ws = self.init(
             url: url,

--- a/Sources/HummingbirdWSClient/WebSocketClientChannel.swift
+++ b/Sources/HummingbirdWSClient/WebSocketClientChannel.swift
@@ -30,10 +30,10 @@ struct WebSocketClientChannel: ClientConnectionChannel {
 
     let urlPath: String
     let hostHeader: String
-    let handler: WebSocketDataHandler<BasicWebSocketContext>
+    let handler: WebSocketDataHandler<WebSocketClient.Context>
     let configuration: WebSocketClientConfiguration
 
-    init(handler: @escaping WebSocketDataHandler<BasicWebSocketContext>, url: URI, configuration: WebSocketClientConfiguration) throws {
+    init(handler: @escaping WebSocketDataHandler<WebSocketClient.Context>, url: URI, configuration: WebSocketClientConfiguration) throws {
         guard let hostHeader = Self.urlHostHeader(for: url) else { throw WebSocketClientError.invalidURL }
         self.hostHeader = hostHeader
         self.urlPath = Self.urlPath(for: url)
@@ -104,7 +104,7 @@ struct WebSocketClientChannel: ClientConnectionChannel {
                     autoPing: self.configuration.autoPing
                 ),
                 asyncChannel: webSocketChannel,
-                context: BasicWebSocketContext(allocator: webSocketChannel.channel.allocator, logger: logger),
+                context: WebSocketClient.Context(allocator: webSocketChannel.channel.allocator, logger: logger),
                 handler: self.handler
             )
         case .notUpgraded:

--- a/Sources/HummingbirdWSCore/WebSocketContext.swift
+++ b/Sources/HummingbirdWSCore/WebSocketContext.swift
@@ -15,21 +15,8 @@
 import Logging
 import NIOCore
 
-/// Context for WebSocket
+/// Protocol for WebSocket Data handling functions context parameter
 public protocol WebSocketContext: Sendable {
     var allocator: ByteBufferAllocator { get }
     var logger: Logger { get }
-}
-
-/// Basic context implementation of ``WebSocketContext``.
-///
-/// Used by non-router and client WebSocket connections
-public struct BasicWebSocketContext: WebSocketContext {
-    public let allocator: ByteBufferAllocator
-    public let logger: Logger
-
-    package init(allocator: ByteBufferAllocator, logger: Logger) {
-        self.allocator = allocator
-        self.logger = logger
-    }
 }

--- a/Sources/HummingbirdWSCore/WebSocketExtension.swift
+++ b/Sources/HummingbirdWSCore/WebSocketExtension.swift
@@ -14,16 +14,29 @@
 
 import Foundation
 import HTTPTypes
+import Logging
+import NIOCore
 import NIOWebSocket
+
+/// Basic context implementation of ``WebSocketContext``.
+public struct WebSocketExtensionContext {
+    public let allocator: ByteBufferAllocator
+    public let logger: Logger
+
+    init(allocator: ByteBufferAllocator, logger: Logger) {
+        self.allocator = allocator
+        self.logger = logger
+    }
+}
 
 /// Protocol for WebSocket extension
 public protocol WebSocketExtension: Sendable {
     /// Extension name
     var name: String { get }
     /// Process frame received from websocket
-    func processReceivedFrame(_ frame: WebSocketFrame, context: some WebSocketContext) async throws -> WebSocketFrame
+    func processReceivedFrame(_ frame: WebSocketFrame, context: WebSocketExtensionContext) async throws -> WebSocketFrame
     /// Process frame about to be sent to websocket
-    func processFrameToSend(_ frame: WebSocketFrame, context: some WebSocketContext) async throws -> WebSocketFrame
+    func processFrameToSend(_ frame: WebSocketFrame, context: WebSocketExtensionContext) async throws -> WebSocketFrame
     /// shutdown extension
     func shutdown() async
 }

--- a/Sources/HummingbirdWSCore/WebSocketHandler.swift
+++ b/Sources/HummingbirdWSCore/WebSocketHandler.swift
@@ -188,7 +188,7 @@ package actor WebSocketHandler {
                         }
                     }
                 }
-            // don't propagate error if channel is already closed
+                // don't propagate error if channel is already closed
             } catch ChannelError.ioOnClosedChannel {}
         } onGracefulShutdown: {
             Task {

--- a/Sources/HummingbirdWSCore/WebSocketHandler.swift
+++ b/Sources/HummingbirdWSCore/WebSocketHandler.swift
@@ -54,6 +54,17 @@ public struct WebSocketCloseFrame {
 /// Manages ping, pong and close messages. Collates data and text messages into final frame
 /// and passes them onto the ``WebSocketDataHandler`` data handler setup by the user.
 package actor WebSocketHandler {
+    /// Basic context implementation of ``WebSocketContext``.
+    public struct Context: WebSocketContext {
+        public let allocator: ByteBufferAllocator
+        public let logger: Logger
+
+        package init(allocator: ByteBufferAllocator, logger: Logger) {
+            self.allocator = allocator
+            self.logger = logger
+        }
+    }
+
     enum InternalError: Error {
         case close(WebSocketErrorCode)
     }
@@ -78,7 +89,7 @@ package actor WebSocketHandler {
     var outbound: NIOAsyncChannelOutboundWriter<WebSocketFrame>
     let type: WebSocketType
     let configuration: Configuration
-    let context: BasicWebSocketContext
+    let context: Context
     var pingData: ByteBuffer
     var pingTime: ContinuousClock.Instant = .now
     var closeState: CloseState

--- a/Sources/HummingbirdWSCore/WebSocketInboundStream.swift
+++ b/Sources/HummingbirdWSCore/WebSocketInboundStream.swift
@@ -86,7 +86,10 @@ public final class WebSocketInboundStream: AsyncSequence, Sendable {
                     // catch errors while processing websocket frames so responding close message
                     // can be dealt with
                     let errorCode = WebSocketErrorCode(error)
-                    try await self.handler.close(code: errorCode)
+                    do {
+                        try await self.handler.close(code: errorCode)
+                    // don't propagate error if channel is already closed
+                    } catch ChannelError.ioOnClosedChannel {}
                 }
             }
 

--- a/Sources/HummingbirdWSCore/WebSocketInboundStream.swift
+++ b/Sources/HummingbirdWSCore/WebSocketInboundStream.swift
@@ -88,7 +88,7 @@ public final class WebSocketInboundStream: AsyncSequence, Sendable {
                     let errorCode = WebSocketErrorCode(error)
                     do {
                         try await self.handler.close(code: errorCode)
-                    // don't propagate error if channel is already closed
+                        // don't propagate error if channel is already closed
                     } catch ChannelError.ioOnClosedChannel {}
                 }
             }

--- a/Sources/HummingbirdWSCore/WebSocketOutboundWriter.swift
+++ b/Sources/HummingbirdWSCore/WebSocketOutboundWriter.swift
@@ -40,7 +40,7 @@ public struct WebSocketOutboundWriter: Sendable {
             try await self.handler.write(frame: .init(fin: true, opcode: .binary, data: buffer))
         case .text(let string):
             // send text based data
-            let buffer = self.handler.context.allocator.buffer(string: string)
+            let buffer = self.handler.allocator.buffer(string: string)
             try await self.handler.write(frame: .init(fin: true, opcode: .text, data: buffer))
         case .pong:
             // send unexplained pong as a heartbeat
@@ -73,7 +73,7 @@ public struct WebSocketOutboundWriter: Sendable {
 
         /// Write string to WebSocket frame
         public mutating func callAsFunction(_ text: String) async throws {
-            let buffer = self.handler.context.allocator.buffer(string: text)
+            let buffer = self.handler.allocator.buffer(string: text)
             try await self.write(buffer, opcode: self.opcode)
         }
 

--- a/Sources/HummingbirdWebSocket/HTTPServerBuilder+WebSocket.swift
+++ b/Sources/HummingbirdWebSocket/HTTPServerBuilder+WebSocket.swift
@@ -25,7 +25,7 @@ extension HTTPServerBuilder {
     public static func http1WebSocketUpgrade(
         configuration: WebSocketServerConfiguration = .init(),
         additionalChannelHandlers: @autoclosure @escaping @Sendable () -> [any RemovableChannelHandler] = [],
-        shouldUpgrade: @escaping @Sendable (HTTPRequest, Channel, Logger) async throws -> ShouldUpgradeResult<WebSocketDataHandler<BasicWebSocketContext>>
+        shouldUpgrade: @escaping @Sendable (HTTPRequest, Channel, Logger) async throws -> ShouldUpgradeResult<WebSocketDataHandler<HTTP1WebSocketUpgradeChannel.Context>>
     ) -> HTTPServerBuilder {
         return .init { responder in
             return HTTP1WebSocketUpgradeChannel(
@@ -41,7 +41,7 @@ extension HTTPServerBuilder {
     public static func http1WebSocketUpgrade(
         configuration: WebSocketServerConfiguration = .init(),
         additionalChannelHandlers: @autoclosure @escaping @Sendable () -> [any RemovableChannelHandler] = [],
-        shouldUpgrade: @escaping @Sendable (HTTPRequest, Channel, Logger) throws -> ShouldUpgradeResult<WebSocketDataHandler<BasicWebSocketContext>>
+        shouldUpgrade: @escaping @Sendable (HTTPRequest, Channel, Logger) throws -> ShouldUpgradeResult<WebSocketDataHandler<HTTP1WebSocketUpgradeChannel.Context>>
     ) -> HTTPServerBuilder {
         return .init { responder in
             return HTTP1WebSocketUpgradeChannel(

--- a/Sources/HummingbirdWebSocket/WebSocketChannel.swift
+++ b/Sources/HummingbirdWebSocket/WebSocketChannel.swift
@@ -39,6 +39,18 @@ public struct HTTP1WebSocketUpgradeChannel: ServerChildChannel, HTTPChannelHandl
         public let channel: Channel
     }
 
+    /// Basic context implementation of ``WebSocketContext``.
+    /// Used by non-router web socket handle function
+    public struct Context: WebSocketContext {
+        public let allocator: ByteBufferAllocator
+        public let logger: Logger
+
+        package init(allocator: ByteBufferAllocator, logger: Logger) {
+            self.allocator = allocator
+            self.logger = logger
+        }
+    }
+
     ///  Initialize HTTP1AndWebSocketChannel with synchronous `shouldUpgrade` function
     /// - Parameters:
     ///   - additionalChannelHandlers: Additional channel handlers to add
@@ -50,7 +62,7 @@ public struct HTTP1WebSocketUpgradeChannel: ServerChildChannel, HTTPChannelHandl
         responder: @escaping HTTPChannelHandler.Responder,
         configuration: WebSocketServerConfiguration,
         additionalChannelHandlers: @escaping @Sendable () -> [any RemovableChannelHandler] = { [] },
-        shouldUpgrade: @escaping @Sendable (HTTPRequest, Channel, Logger) throws -> ShouldUpgradeResult<WebSocketDataHandler<BasicWebSocketContext>>
+        shouldUpgrade: @escaping @Sendable (HTTPRequest, Channel, Logger) throws -> ShouldUpgradeResult<WebSocketDataHandler<Context>>
     ) {
         self.additionalChannelHandlers = additionalChannelHandlers
         self.configuration = configuration
@@ -65,7 +77,7 @@ public struct HTTP1WebSocketUpgradeChannel: ServerChildChannel, HTTPChannelHandl
                             logger: logger
                         )
                         return (headers, { asyncChannel, logger in
-                            let context = BasicWebSocketContext(allocator: channel.allocator, logger: logger)
+                            let context = Context(allocator: channel.allocator, logger: logger)
                             do {
                                 _ = try await WebSocketHandler.handle(
                                     type: .server,
@@ -98,7 +110,7 @@ public struct HTTP1WebSocketUpgradeChannel: ServerChildChannel, HTTPChannelHandl
         responder: @escaping HTTPChannelHandler.Responder,
         configuration: WebSocketServerConfiguration,
         additionalChannelHandlers: @escaping @Sendable () -> [any RemovableChannelHandler] = { [] },
-        shouldUpgrade: @escaping @Sendable (HTTPRequest, Channel, Logger) async throws -> ShouldUpgradeResult<WebSocketDataHandler<BasicWebSocketContext>>
+        shouldUpgrade: @escaping @Sendable (HTTPRequest, Channel, Logger) async throws -> ShouldUpgradeResult<WebSocketDataHandler<Context>>
     ) {
         self.additionalChannelHandlers = additionalChannelHandlers
         self.configuration = configuration
@@ -114,7 +126,7 @@ public struct HTTP1WebSocketUpgradeChannel: ServerChildChannel, HTTPChannelHandl
                             logger: logger
                         )
                         return (headers, { asyncChannel, logger in
-                            let context = BasicWebSocketContext(allocator: channel.allocator, logger: logger)
+                            let context = Context(allocator: channel.allocator, logger: logger)
                             do {
                                 _ = try await WebSocketHandler.handle(
                                     type: .server,

--- a/Tests/HummingbirdWebSocketTests/WebSocketExtensionTests.swift
+++ b/Tests/HummingbirdWebSocketTests/WebSocketExtensionTests.swift
@@ -310,7 +310,7 @@ struct XorWebSocketExtension: WebSocketExtension {
     let name = "xor"
     func shutdown() {}
 
-    func xorFrame(_ frame: WebSocketFrame, context: some WebSocketContext) -> WebSocketFrame {
+    func xorFrame(_ frame: WebSocketFrame, context: WebSocketExtensionContext) -> WebSocketFrame {
         var newBuffer = context.allocator.buffer(capacity: frame.data.readableBytes)
         for byte in frame.unmaskedData.readableBytesView {
             newBuffer.writeInteger(byte ^ self.value)
@@ -321,11 +321,11 @@ struct XorWebSocketExtension: WebSocketExtension {
         return frame
     }
 
-    func processReceivedFrame(_ frame: WebSocketFrame, context: some WebSocketContext) -> WebSocketFrame {
+    func processReceivedFrame(_ frame: WebSocketFrame, context: WebSocketExtensionContext) -> WebSocketFrame {
         return self.xorFrame(frame, context: context)
     }
 
-    func processFrameToSend(_ frame: WebSocketFrame, context: some WebSocketContext) throws -> WebSocketFrame {
+    func processFrameToSend(_ frame: WebSocketFrame, context: WebSocketExtensionContext) throws -> WebSocketFrame {
         return self.xorFrame(frame, context: context)
     }
 
@@ -377,12 +377,12 @@ struct CheckDeflateWebSocketExtension: WebSocketExtension {
     let name = "check-deflate"
     func shutdown() {}
 
-    func processReceivedFrame(_ frame: WebSocketFrame, context: some WebSocketContext) throws -> WebSocketFrame {
+    func processReceivedFrame(_ frame: WebSocketFrame, context: WebSocketExtensionContext) throws -> WebSocketFrame {
         guard frame.rsv1 else { throw NoDeflateError() }
         return frame
     }
 
-    func processFrameToSend(_ frame: WebSocketFrame, context: some WebSocketContext) throws -> WebSocketFrame {
+    func processFrameToSend(_ frame: WebSocketFrame, context: WebSocketExtensionContext) throws -> WebSocketFrame {
         return frame
     }
 }

--- a/Tests/HummingbirdWebSocketTests/WebSocketExtensionTests.swift
+++ b/Tests/HummingbirdWebSocketTests/WebSocketExtensionTests.swift
@@ -28,7 +28,7 @@ final class HummingbirdWebSocketExtensionTests: XCTestCase {
     func testClientAndServer(
         serverChannel: HTTPServerBuilder,
         clientExtensions: [WebSocketExtensionFactory] = [],
-        client clientHandler: @escaping WebSocketDataHandler<BasicWebSocketContext>
+        client clientHandler: @escaping WebSocketDataHandler<WebSocketClient.Context>
     ) async throws {
         try await withThrowingTaskGroup(of: Void.self) { group in
             let promise = Promise<Int>()
@@ -89,8 +89,8 @@ final class HummingbirdWebSocketExtensionTests: XCTestCase {
     func testClientAndServer(
         serverExtensions: [WebSocketExtensionFactory] = [],
         clientExtensions: [WebSocketExtensionFactory] = [],
-        server serverHandler: @escaping WebSocketDataHandler<BasicWebSocketContext>,
-        client clientHandler: @escaping WebSocketDataHandler<BasicWebSocketContext>
+        server serverHandler: @escaping WebSocketDataHandler<HTTP1WebSocketUpgradeChannel.Context>,
+        client clientHandler: @escaping WebSocketDataHandler<WebSocketClient.Context>
     ) async throws {
         try await self.testClientAndServer(
             serverChannel: .http1WebSocketUpgrade(configuration: .init(extensions: serverExtensions)) { _, _, _ in

--- a/Tests/HummingbirdWebSocketTests/WebSocketTests.swift
+++ b/Tests/HummingbirdWebSocketTests/WebSocketTests.swift
@@ -125,7 +125,7 @@ final class HummingbirdWebSocketTests: XCTestCase {
 
     @discardableResult func testClientAndServer(
         serverTLSConfiguration: TLSConfiguration? = nil,
-        server serverHandler: @escaping WebSocketDataHandler<BasicWebSocketContext>,
+        server serverHandler: @escaping WebSocketDataHandler<HTTP1WebSocketUpgradeChannel.Context>,
         shouldUpgrade: @escaping @Sendable (HTTPRequest) throws -> HTTPFields? = { _ in return [:] },
         getClient: @escaping @Sendable (Int, Logger) throws -> WebSocketClient
     ) async throws -> WebSocketCloseFrame? {
@@ -151,9 +151,9 @@ final class HummingbirdWebSocketTests: XCTestCase {
 
     @discardableResult func testClientAndServer(
         serverTLSConfiguration: TLSConfiguration? = nil,
-        server serverHandler: @escaping WebSocketDataHandler<BasicWebSocketContext>,
+        server serverHandler: @escaping WebSocketDataHandler<HTTP1WebSocketUpgradeChannel.Context>,
         shouldUpgrade: @escaping @Sendable (HTTPRequest) throws -> HTTPFields? = { _ in return [:] },
-        client clientHandler: @escaping WebSocketDataHandler<BasicWebSocketContext>
+        client clientHandler: @escaping WebSocketDataHandler<WebSocketClient.Context>
     ) async throws -> WebSocketCloseFrame? {
         return try await self.testClientAndServer(
             serverTLSConfiguration: serverTLSConfiguration,


### PR DESCRIPTION
- Add WebSocketClient.Context
- Add WebSocketExtensionContext
- Add HTTP1WebSocketUpgradeChannel.Context
- Remove BasicWebSocketContext

Makes it clearer what contexts are for, removes one top level public symbol