### PR TITLE
Disable pipelining support and response header validation for HTTP

### DIFF
--- a/Sources/HummingbirdWebSocket/WebSocketChannel.swift
+++ b/Sources/HummingbirdWebSocket/WebSocketChannel.swift
@@ -210,9 +210,11 @@ public struct HTTP1WebSocketUpgradeChannel: ServerChildChannel, HTTPChannelHandl
                     }
                 }
             )
-
+            var upgradeConfiguration = NIOUpgradableHTTPServerPipelineConfiguration<UpgradeResult>(upgradeConfiguration: serverUpgradeConfiguration)
+            upgradeConfiguration.enablePipelining = false  // HTTP is pipelined by NIOAsyncChannel
+            upgradeConfiguration.enableResponseHeaderValidation = false  // Swift HTTP Types are already doing this validation
             let negotiationResultFuture = try channel.pipeline.syncOperations.configureUpgradableHTTPServerPipeline(
-                configuration: .init(upgradeConfiguration: serverUpgradeConfiguration)
+                configuration: upgradeConfiguration
             )
 
             return .init(upgradeResult: negotiationResultFuture, channel: channel)


### PR DESCRIPTION
- Pipelining support should not be necessary as the NIOAsyncChannel ensures we are only processing one request at a time
- Response header validation is unnecessary because the new HTTP types do this validation for us

These are the settings used in the standard HTTP1Channel