### PR TITLE
Write empty 200 response for failed upgrade

### DIFF
--- a/Sources/HummingbirdWebSocket/WebSocketChannel.swift
+++ b/Sources/HummingbirdWebSocket/WebSocketChannel.swift
@@ -241,7 +241,7 @@ public struct HTTP1WebSocketUpgradeChannel: ServerChildChannel, HTTPChannelHandl
 
             case .failedUpgrade(let http1, let logger):
                 logger.debug("Websocket upgrade failed")
-                await self.write405(asyncChannel: http1, logger: logger)
+                await self.writeFailedUpgrade(asyncChannel: http1, logger: logger)
 
             case .websocket(let asyncChannel, let handler, let logger):
                 logger.debug("Websocket upgrade")
@@ -254,8 +254,8 @@ public struct HTTP1WebSocketUpgradeChannel: ServerChildChannel, HTTPChannelHandl
         }
     }
 
-    /// Upgrade failed we should write a 405
-    private func write405(asyncChannel: NIOAsyncChannel<HTTPRequestPart, HTTPResponsePart>, logger: Logger) async {
+    /// Write empty HTTP response for failed upgrade
+    private func writeFailedUpgrade(asyncChannel: NIOAsyncChannel<HTTPRequestPart, HTTPResponsePart>, logger: Logger) async {
         do {
             try await asyncChannel.executeThenClose { _, outbound in
                 let headers: HTTPFields = [
@@ -263,7 +263,7 @@ public struct HTTP1WebSocketUpgradeChannel: ServerChildChannel, HTTPChannelHandl
                     .contentLength: "0",
                 ]
                 let head = HTTPResponse(
-                    status: .methodNotAllowed,
+                    status: .ok,
                     headerFields: headers
                 )
 

--- a/Sources/HummingbirdWebSocket/WebSocketChannel.swift
+++ b/Sources/HummingbirdWebSocket/WebSocketChannel.swift
@@ -263,7 +263,7 @@ public struct HTTP1WebSocketUpgradeChannel: ServerChildChannel, HTTPChannelHandl
                     .contentLength: "0",
                 ]
                 let head = HTTPResponse(
-                    status: .ok,
+                    status: .badRequest,
                     headerFields: headers
                 )
 

--- a/Tests/HummingbirdWebSocketTests/WebSocketTests.swift
+++ b/Tests/HummingbirdWebSocketTests/WebSocketTests.swift
@@ -815,7 +815,10 @@ final class HummingbirdWebSocketTests: XCTestCase {
             server: .http1WebSocketUpgrade { request, channel, logger in
                 .dontUpgrade
             },
-            onServerRunning: { cont.yield($0.localAddress!.port!) }
+            configuration: .init(address: .hostname("127.0.0.1", port: 0)),
+            onServerRunning: {
+                cont.yield($0.localAddress!.port!)
+            }
         )
         do {
             try await withThrowingTaskGroup(of: Void.self) { group in


### PR DESCRIPTION
For some reason I was returning a 405 (Method Not Allowed) which doesn't make sense.
Looking around on the web it seems an empty 200 is the standard response for a failed upgrade