### PR TITLE
If we receive an upgrade request after not upgrading, return redirect and close connection

### DIFF
--- a/Sources/HummingbirdWebSocket/WebSocketChannel.swift
+++ b/Sources/HummingbirdWebSocket/WebSocketChannel.swift
@@ -173,9 +173,11 @@ public struct HTTP1WebSocketUpgradeChannel: ServerChildChannel, HTTPChannelHandl
     static func getUpgradeResponder(_ responder: @escaping HTTPChannelHandler.Responder) -> HTTPChannelHandler.Responder {
         struct RedirectCloseError: Error {}
         return {
-            request,
-            responseWriter,
-            context in
+            (
+                request: Request,
+                responseWriter: consuming ResponseWriter,
+                channel: Channel
+            ) in
             if request.headers[.upgrade] == "websocket" {
                 var path = request.uri.path
                 if let query = request.uri.query {
@@ -189,7 +191,7 @@ public struct HTTP1WebSocketUpgradeChannel: ServerChildChannel, HTTPChannelHandl
                 try await responseWriter.writeResponse(response)
                 throw RedirectCloseError()
             } else {
-                try await responder(request, responseWriter, context)
+                try await responder(request, responseWriter, channel)
             }
         }
     }

--- a/Sources/HummingbirdWebSocket/WebSocketChannel.swift
+++ b/Sources/HummingbirdWebSocket/WebSocketChannel.swift
@@ -177,9 +177,13 @@ public struct HTTP1WebSocketUpgradeChannel: ServerChildChannel, HTTPChannelHandl
             responseWriter,
             context in
             if request.headers[.upgrade] == "websocket" {
+                var path = request.uri.path
+                if let query = request.uri.query {
+                    path += "?\(query)"
+                }
                 let headers: HTTPFields = [
                     .connection: "close",
-                    .location: request.uri.path,
+                    .location: path,
                 ]
                 let response = HTTPResponse(status: .temporaryRedirect, headerFields: headers)
                 try await responseWriter.writeResponse(response)

--- a/Sources/HummingbirdWebSocket/WebSocketChannel.swift
+++ b/Sources/HummingbirdWebSocket/WebSocketChannel.swift
@@ -170,6 +170,19 @@ public struct HTTP1WebSocketUpgradeChannel: ServerChildChannel, HTTPChannelHandl
         self.responder = Self.getUpgradeResponder(responder)
     }
 
+    /// Return HTTP responder that responds with a redirect and connection closure on receiving an
+    /// upgrade header set to websocket
+    ///
+    /// The responder passed in as a parameter is called from the resultant responder if no upgrade
+    /// header is found.
+    ///
+    /// This is a temporary solution to the fact that the NIO upgrade code does not support parsing
+    /// upgrade headers after having received a normal HTTP request. By returning a redirect to the
+    /// same URI and closing the connection we are forcing the client to open a new connection
+    /// where the upgrade code path will run.
+    ///
+    /// - Parameter responder: HTTP responder to call
+    /// - Returns: Result of HTTP responder or redirect
     static func getUpgradeResponder(_ responder: @escaping HTTPChannelHandler.Responder) -> HTTPChannelHandler.Responder {
         struct RedirectCloseError: Error {}
         return {

--- a/Sources/HummingbirdWebSocket/WebSocketRouter.swift
+++ b/Sources/HummingbirdWebSocket/WebSocketRouter.swift
@@ -192,7 +192,7 @@ extension HTTP1WebSocketUpgradeChannel {
             }
             return promise.futureResult
         }
-        self.responder = responder
+        self.responder = Self.getUpgradeResponder(responder)
     }
 }
 


### PR DESCRIPTION
If we close the connection and return a temporary redirect to the same URI, Safari will open a new connection and the WebSocket upgrade works