### PR TITLE
Feature/continue to http

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,80 @@ let app = Application(
 app.runService()
 ```
 
+## Socket.IO-style Dual Transport
+
+You can implement Socket.IO-style servers that handle both HTTP polling and WebSocket connections at the same endpoint using `.httpResponse()`:
+
+```swift
+let router = Router(context: BasicWebSocketRequestContext.self)
+
+// Single route handles both HTTP polling and WebSocket upgrade
+router.ws("/socket.io") { request, context in
+    let transport = request.uri.queryParameters["transport"] ?? "polling"
+    
+    if transport == "websocket" {
+        // Upgrade to WebSocket
+        return .upgrade([:])
+    } else {
+        // Handle HTTP polling
+        let pollingResponse = handleSocketIOPolling(request, context)
+        return .httpResponse(pollingResponse)
+    }
+} onUpgrade: { inbound, outbound, context in
+    // Handle WebSocket connection
+    for try await packet in inbound {
+        // Echo messages back to client
+        try await outbound.write(packet)
+    }
+}
+
+let app = Application(
+    router: router,
+    server: .http1WebSocketUpgrade(webSocketRouter: router)
+)
+app.runService()
+
+func handleSocketIOPolling(_ request: Request, _ context: BasicWebSocketRequestContext) -> Response {
+    // Implement Socket.IO polling logic
+    let sessionId = UUID().uuidString
+    let response = """
+    {"sid":"\(sessionId)","upgrades":["websocket"],"pingInterval":25000,"pingTimeout":20000}
+    """
+    return Response(
+        status: .ok,
+        headers: [.contentType: "application/json"],
+        body: .init(byteBuffer: ByteBuffer(string: response))
+    )
+}
+```
+
+### Alternative: Middleware Pattern
+
+For more complex routing scenarios, you can use middleware with `.continueToHTTP`:
+
+```swift
+let router = Router(context: BasicWebSocketRequestContext.self)
+
+router.group("/socket.io")
+    .add(middleware: WebSocketUpgradeMiddleware { request, context in
+        let transport = request.uri.queryParameters["transport"] ?? "polling"
+        return transport == "websocket" ? .upgrade([:]) : .continueToHTTP
+    } onUpgrade: { inbound, outbound, context in
+        // Handle WebSocket connection
+        try await outbound.write(.text("WebSocket connected"))
+    })
+    .get { request, context in
+        // Handle HTTP polling requests
+        return handleSocketIOPolling(request, context)
+    }
+```
+
+This enables:
+- ✅ Socket.IO server implementation
+- ✅ Server-Sent Events with WebSocket fallback  
+- ✅ GraphQL subscriptions with transport negotiation
+- ✅ Any dual-transport real-time protocol
+
 ## Documentation
 
 You can find documentation for HummingbirdWebSocket [here](https://hummingbird-project.github.io/hummingbird-docs/2.0/documentation/hummingbirdwebsocket). The [hummingbird-examples](https://github.com/hummingbird-project/hummingbird-examples) repository has a number of examples of different uses of the library.

--- a/Snippets/WebsocketTest.swift
+++ b/Snippets/WebsocketTest.swift
@@ -1,3 +1,4 @@
+import Foundation
 import HTTPTypes
 import Hummingbird
 import HummingbirdWebSocket
@@ -13,6 +14,46 @@ router.get { _, _ in
     "Hello"
 }
 
+// Socket.IO-style dual transport example
+router.ws("/socket.io") { request, context in
+    let transport = request.uri.queryParameters["transport"] ?? "polling"
+    
+    if transport == "websocket" {
+        return .upgrade([:])
+    } else {
+        // Handle HTTP polling
+        let sessionId = UUID().uuidString
+        let response = """
+        {"sid":"\(sessionId)","upgrades":["websocket"],"pingInterval":25000,"pingTimeout":20000}
+        """
+        return .httpResponse(Response(
+            status: .ok,
+            headers: [.contentType: "application/json"],
+            body: .init(byteBuffer: ByteBuffer(string: response))
+        ))
+    }
+} onUpgrade: { inbound, outbound, context in
+    try await outbound.write(.text("Socket.IO WebSocket connected"))
+    for try await frame in inbound {
+        if frame.opcode == .text, String(buffer: frame.data) == "disconnect", frame.fin == true {
+            break
+        }
+        let opcode: WebSocketOpcode =
+            switch frame.opcode {
+            case .text: .text
+            case .binary: .binary
+            case .continuation: .continuation
+            }
+        let frame = WebSocketFrame(
+            fin: frame.fin,
+            opcode: opcode,
+            data: frame.data
+        )
+        try await outbound.write(.custom(frame))
+    }
+}
+
+// Regular WebSocket route
 router.ws("/ws") { inbound, outbound, _ in
     try await outbound.write(.text("Hello"))
     for try await frame in inbound {


### PR DESCRIPTION
I'm opening this draft PR because I ran into a case that I believe isn't currently covered required for socket.io. I have added a `continueToHTTP` case to `ShouldUpgradeResult`.

The (mostly vibe coded) code is still rough and needs cleanup, but before spending more time on it, I wanted to see if there’s interest in supporting this use case.

If this is a direction the project wants to go in, I’ll tidy up the code and update the branch.