### PR TITLE
Pass maxFrameSize to WebSocketHandler

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.23.0"),
-        .package(url: "https://github.com/hummingbird-project/swift-websocket.git", from: "1.5.0"),
+        .package(url: "https://github.com/hummingbird-project/swift-websocket.git", from: "1.6.0"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.22.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.5.0"),
     ],

--- a/Sources/HummingbirdWebSocket/WebSocketChannel.swift
+++ b/Sources/HummingbirdWebSocket/WebSocketChannel.swift
@@ -116,7 +116,8 @@ public struct HTTP1WebSocketUpgradeChannel: ServerChildChannel, HTTPChannelHandl
                                             extensions: extensions,
                                             autoPing: configuration.ws.autoPing,
                                             closeTimeout: configuration.ws.closeTimeout,
-                                            validateUTF8: configuration.ws.validateUTF8
+                                            validateUTF8: configuration.ws.validateUTF8,
+                                            maxFrameSize: configuration.ws.maxFrameSize
                                         ),
                                         asyncChannel: asyncChannel,
                                         context: context,
@@ -205,7 +206,8 @@ public struct HTTP1WebSocketUpgradeChannel: ServerChildChannel, HTTPChannelHandl
                                             extensions: extensions,
                                             autoPing: configuration.ws.autoPing,
                                             closeTimeout: configuration.ws.closeTimeout,
-                                            validateUTF8: configuration.ws.validateUTF8
+                                            validateUTF8: configuration.ws.validateUTF8,
+                                            maxFrameSize: configuration.ws.maxFrameSize
                                         ),
                                         asyncChannel: asyncChannel,
                                         context: context,

--- a/Sources/HummingbirdWebSocket/WebSocketRouter.swift
+++ b/Sources/HummingbirdWebSocket/WebSocketRouter.swift
@@ -189,7 +189,8 @@ extension HTTP1WebSocketUpgradeChannel {
                                         extensions: extensions,
                                         autoPing: configuration.ws.autoPing,
                                         closeTimeout: configuration.ws.closeTimeout,
-                                        validateUTF8: configuration.ws.validateUTF8
+                                        validateUTF8: configuration.ws.validateUTF8,
+                                        maxFrameSize: configuration.ws.maxFrameSize
                                     ),
                                     asyncChannel: asyncChannel,
                                     context: WebSocketRouterContext(request: request, context: webSocketHandler.context),

--- a/Tests/HummingbirdWebSocketTests/WebSocketTests.swift
+++ b/Tests/HummingbirdWebSocketTests/WebSocketTests.swift
@@ -235,8 +235,8 @@ struct HummingbirdWebSocketTests {
             router: Router(),
             server: .http1WebSocketUpgrade(configuration: .init(ws: .init(maxFrameSize: 2048))) { _, _, _ in
                 .upgrade([:]) { inbound, outbound, _ in
-                    try await outbound.writeBuffer(buffer1)
-                    try await outbound.writeBuffer(buffer2)
+                    try await outbound.writeBinaryMessage(buffer1)
+                    try await outbound.writeBinaryMessage(buffer2)
                     for try await _ in inbound {}
                 }
             },

--- a/Tests/HummingbirdWebSocketTests/WebSocketTests.swift
+++ b/Tests/HummingbirdWebSocketTests/WebSocketTests.swift
@@ -227,6 +227,59 @@ struct HummingbirdWebSocketTests {
         }
     }
 
+    // test binary buffer across multiple frames works
+    @Test func testMultiFrameBinaryMessage() async throws {
+        let buffer1 = createRandomBuffer(size: 7000)
+        let buffer2 = createRandomBuffer(size: 120)
+        let app = Application(
+            router: Router(),
+            server: .http1WebSocketUpgrade(configuration: .init(ws: .init(maxFrameSize: 2048))) { _, _, _ in
+                .upgrade([:]) { inbound, outbound, _ in
+                    try await outbound.writeBuffer(buffer1)
+                    try await outbound.writeBuffer(buffer2)
+                    for try await _ in inbound {}
+                }
+            },
+            configuration: .init(address: .hostname("127.0.0.1", port: 0))
+        )
+        try await app.test(.live) { client in
+            let closeFrame = try await client.ws("/") { inbound, _, _ in
+                var iterator = inbound.messages(maxSize: .max).makeAsyncIterator()
+                var message = try await iterator.next()
+                #expect(.binary(buffer1) == message)
+                message = try await iterator.next()
+                #expect(.binary(buffer2) == message)
+            }
+            #expect(closeFrame?.closeCode == .normalClosure)
+        }
+    }
+
+    // test text buffer across multiple frames works
+    @Test func testMultiFrameTextMessage() async throws {
+        let characters: [Character] = ["a", "é", "🌍"]
+        let string = String((0..<6096).map { _ in characters.randomElement()! })
+        let app = Application(
+            router: Router(),
+            server: .http1WebSocketUpgrade(configuration: .init(ws: .init(maxFrameSize: 2048))) { _, _, _ in
+                .upgrade([:]) { inbound, outbound, _ in
+                    try await outbound.writeTextMessage("Hello world!")
+                    try await outbound.writeTextMessage(string)
+                    for try await _ in inbound {}
+                }
+            },
+            configuration: .init(address: .hostname("127.0.0.1", port: 0))
+        )
+        _ = try await app.test(.live) { client in
+            try await client.ws("/") { inbound, _, _ in
+                var iterator = inbound.messages(maxSize: .max).makeAsyncIterator()
+                var message = try await iterator.next()
+                #expect(.text("Hello world!") == message)
+                message = try await iterator.next()
+                #expect(.text(string) == message)
+            }
+        }
+    }
+
     @Test func testWebSocketUpgradeFailed() async throws {
         let app = Application(
             router: Router(),


### PR DESCRIPTION
The WebSocketHandler needs the maxFrameSize so it knows how to breakup large messages into multiple frames. See https://github.com/hummingbird-project/swift-websocket/pull/49