### PR TITLE
Expose HTTP decoder configuration

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "HummingbirdWSTesting", targets: ["HummingbirdWSTesting"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.23.0"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.24.0"),
         .package(url: "https://github.com/hummingbird-project/swift-websocket.git", from: "1.6.0"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.22.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.5.0"),

--- a/Sources/HummingbirdWebSocket/WebSocketChannel.swift
+++ b/Sources/HummingbirdWebSocket/WebSocketChannel.swift
@@ -280,7 +280,7 @@ public struct HTTP1WebSocketUpgradeChannel: ServerChildChannel, HTTPChannelHandl
                     upgradeAttempted.value = true
                     return self.shouldUpgrade(head, channel, logger)
                 },
-                upgradePipelineHandler: { channel, handler in
+                upgradePipelineHandler: { (channel, handler: @escaping WebSocketChannelHandler) in
                     channel.eventLoop.makeCompletedFuture {
                         let asyncChannel = try NIOAsyncChannel<WebSocketFrame, WebSocketFrame>(
                             wrappingChannelSynchronously: channel,
@@ -316,6 +316,9 @@ public struct HTTP1WebSocketUpgradeChannel: ServerChildChannel, HTTPChannelHandl
             upgradeConfiguration.enablePipelining = false  // HTTP is pipelined by NIOAsyncChannel
             upgradeConfiguration.enableErrorHandling = false  // These are handled by Hummingbird
             upgradeConfiguration.enableResponseHeaderValidation = false  // Swift HTTP Types are already doing this validation
+            upgradeConfiguration.decoderConfiguration.maxHeaderFieldSize = self.configuration.http1.httpDecoder.maxHeaderFieldSize
+            upgradeConfiguration.decoderConfiguration.maxHeaderListSize = self.configuration.http1.httpDecoder.maxHeaderListSize
+            upgradeConfiguration.decoderConfiguration.maxHeaderFieldCount = self.configuration.http1.httpDecoder.maxHeaderFieldCount
             let negotiationResultFuture = try channel.pipeline.syncOperations.configureUpgradableHTTPServerPipeline(
                 configuration: upgradeConfiguration
             )


### PR DESCRIPTION
This PR exposes the HTTP decoder configuration for HTTP connections when WebSocket upgrade doesn't happen